### PR TITLE
custom exception, controllerAdvice 적용하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/numble/instagram/dto/response/ErrorResponse.java
+++ b/src/main/java/com/numble/instagram/dto/response/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.numble.instagram.dto.response;
+
+import lombok.Builder;
+
+import java.util.Map;
+
+public record ErrorResponse(int code, String message, Map<String, String> validation) {
+
+    @Builder
+    public ErrorResponse(int code, String message, Map<String, String> validation) {
+        this.code = code;
+        this.message = message;
+        this.validation = validation != null ? validation : Map.of();
+    }
+}

--- a/src/main/java/com/numble/instagram/exception/CustomException.java
+++ b/src/main/java/com/numble/instagram/exception/CustomException.java
@@ -1,0 +1,22 @@
+package com.numble.instagram.exception;
+
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Getter
+public abstract class CustomException extends RuntimeException {
+
+    public final Map<String, String> validation = new ConcurrentHashMap<>();
+
+    public CustomException(String message) {
+        super(message);
+    }
+
+    public abstract int getStatusCode();
+
+    public void addValidation(String fieldName, String message) {
+        validation.put(fieldName, message);
+    }
+}

--- a/src/main/java/com/numble/instagram/exception/badrequest/InvalidRequestException.java
+++ b/src/main/java/com/numble/instagram/exception/badrequest/InvalidRequestException.java
@@ -1,0 +1,19 @@
+package com.numble.instagram.exception.badrequest;
+
+import com.numble.instagram.exception.CustomException;
+
+public class InvalidRequestException extends CustomException {
+
+    private static final String MESSAGE = "잘못된 요청입니다.";
+
+    private static final int STATUS_CODE = 400;
+
+    public InvalidRequestException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return STATUS_CODE;
+    }
+}

--- a/src/main/java/com/numble/instagram/exception/forbidden/ForbiddenException.java
+++ b/src/main/java/com/numble/instagram/exception/forbidden/ForbiddenException.java
@@ -1,0 +1,19 @@
+package com.numble.instagram.exception.forbidden;
+
+import com.numble.instagram.exception.CustomException;
+
+public class ForbiddenException extends CustomException {
+
+    private static final String MESSAGE = "접근 권한이 없습니다.";
+
+    private static final int STATUS_CODE = 403;
+
+    public ForbiddenException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return STATUS_CODE;
+    }
+}

--- a/src/main/java/com/numble/instagram/exception/notfound/NotFoundException.java
+++ b/src/main/java/com/numble/instagram/exception/notfound/NotFoundException.java
@@ -1,0 +1,19 @@
+package com.numble.instagram.exception.notfound;
+
+import com.numble.instagram.exception.CustomException;
+
+public class NotFoundException extends CustomException {
+
+    private static final String MESSAGE = "리소스를 찾을 수 없습니다.";
+
+    private static final int STATUS_CODE = 404;
+
+    public NotFoundException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return STATUS_CODE;
+    }
+}

--- a/src/main/java/com/numble/instagram/exception/unauthorized/TokenExpiredException.java
+++ b/src/main/java/com/numble/instagram/exception/unauthorized/TokenExpiredException.java
@@ -1,0 +1,8 @@
+package com.numble.instagram.exception.unauthorized;
+
+public class TokenExpiredException extends UnauthorizedException {
+
+    public TokenExpiredException() {
+        addValidation("token", "토큰이 만료되었습니다.");
+    }
+}

--- a/src/main/java/com/numble/instagram/exception/unauthorized/UnauthorizedException.java
+++ b/src/main/java/com/numble/instagram/exception/unauthorized/UnauthorizedException.java
@@ -1,0 +1,19 @@
+package com.numble.instagram.exception.unauthorized;
+
+import com.numble.instagram.exception.CustomException;
+
+public class UnauthorizedException extends CustomException {
+
+    private static final String MESSAGE = "인증되지 않은 사용자입니다.";
+    
+    private static final int STATUS_CODE = 401;
+    
+    public UnauthorizedException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return STATUS_CODE;
+    }
+}

--- a/src/main/java/com/numble/instagram/presentation/CommonControllerAdvice.java
+++ b/src/main/java/com/numble/instagram/presentation/CommonControllerAdvice.java
@@ -1,0 +1,29 @@
+package com.numble.instagram.presentation;
+
+import com.numble.instagram.dto.response.ErrorResponse;
+import com.numble.instagram.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class CommonControllerAdvice {
+
+    private static final String LOG_FORMAT = "Class={}, Code={}, ErrorMessage={}";
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> customException(CustomException e) {
+        int statusCode = e.getStatusCode();
+
+        ErrorResponse body = ErrorResponse.builder()
+                .code(statusCode)
+                .message(e.getMessage())
+                .validation(e.getValidation())
+                .build();
+
+        log.info(LOG_FORMAT, e.getClass().getSimpleName(), e.getStatusCode(), e.getMessage(), e);
+        return ResponseEntity.status(statusCode).body(body);
+    }
+}

--- a/src/main/java/com/numble/instagram/presentation/CommonControllerAdvice.java
+++ b/src/main/java/com/numble/instagram/presentation/CommonControllerAdvice.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class CommonControllerAdvice {
 
-    private static final String LOG_FORMAT = "Class={}, Code={}, ErrorMessage={}";
+    private static final String LOG_FORMAT = "Body={}";
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> customException(CustomException e) {
@@ -23,7 +23,7 @@ public class CommonControllerAdvice {
                 .validation(e.getValidation())
                 .build();
 
-        log.info(LOG_FORMAT, e.getClass().getSimpleName(), e.getStatusCode(), e.getMessage(), e);
+        log.info(LOG_FORMAT, body, e);
         return ResponseEntity.status(statusCode).body(body);
     }
 }

--- a/src/test/java/com/numble/instagram/presentation/CommonControllerAdviceTest.java
+++ b/src/test/java/com/numble/instagram/presentation/CommonControllerAdviceTest.java
@@ -1,0 +1,94 @@
+package com.numble.instagram.presentation;
+
+import com.numble.instagram.exception.badrequest.InvalidRequestException;
+import com.numble.instagram.exception.forbidden.ForbiddenException;
+import com.numble.instagram.exception.notfound.NotFoundException;
+import com.numble.instagram.exception.unauthorized.UnauthorizedException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@AutoConfigureMockMvc
+class CommonControllerAdviceTest {
+
+    MockMvc mockMvc;
+
+    @BeforeAll
+    void setUp() {
+        AdviceTestController controller = new AdviceTestController();
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(CommonControllerAdvice.class)
+                .build();
+    }
+
+    @Test
+    @DisplayName("UnauthorizedException 터지면 controllerAdvice가 작동한다.")
+    void occurUnauthorizedException() throws Exception {
+        mockMvc.perform(get("/unauthorized"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(401))
+                .andExpect(jsonPath("$.message").value("인증되지 않은 사용자입니다."));
+    }
+
+    @Test
+    @DisplayName("NotFoundException 터지면 controllerAdvice가 작동한다.")
+    void occurNotFoundException() throws Exception {
+        mockMvc.perform(get("/notFound"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.message").value("리소스를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("ForbiddenException 터지면 controllerAdvice가 작동한다.")
+    void occurForbiddenException() throws Exception {
+        mockMvc.perform(get("/forbidden"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(403))
+                .andExpect(jsonPath("$.message").value("접근 권한이 없습니다."));
+    }
+
+    @Test
+    @DisplayName("InvalidRequestException 터지면 controllerAdvice가 작동한다.")
+    void occurInvalidRequestException() throws Exception {
+        mockMvc.perform(get("/invalidRequest"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+    }
+
+    @RestController
+    static class AdviceTestController {
+        @GetMapping("/unauthorized")
+        public void unauthorized() {
+            throw new UnauthorizedException();
+        }
+
+        @GetMapping("/notFound")
+        public void notFound() {
+            throw new NotFoundException();
+        }
+
+        @GetMapping("/forbidden")
+        public void forbidden() {
+            throw new ForbiddenException();
+        }
+
+        @GetMapping("/invalidRequest")
+        public void invalidRequest() {
+            throw new InvalidRequestException();
+        }
+    }
+}


### PR DESCRIPTION
## 작업 주제

- custom exception, controllerAdvice 적용하기

## optional 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 에러처리를 공통적으로 처리하고 클라이언트에게 메시지를 정확하게 주기 위해 Custom Exception과 ControllerAdvice를 적용했습니다. 
- 이 과정에서 Spring Security가 테스트하는데 지장을 주기 때문에 설정에서 제외했습니다.

## optional 화면 스크린샷

<img width="660" alt="스크린샷 2023-03-27 오후 7 04 11" src="https://user-images.githubusercontent.com/102657974/227910762-8d8eb502-e501-4d37-a147-63999a165fe9.png">

다음과 같이 CustomException을 RuntimeException을 상속받아 작성하였고,  

CustomException을 상속하여 UnauthorizedException, NotFoundException, ForbiddenException, InvalidRequestException을 작성했습니다.  
이후에 필요에 필요에 따라 다음과 같은 Exception을 상속받아 예외관련 클래스들을 validation과 함께 추가할 예정입니다.

## optional 추가 코멘트

- CustomException을 작성 할 때 Java15에 추가된 sealed class를 사용하려 했으나  
- sealed class를 상속받는 클래스는 다른패키지에 있으면 안되는점, 
- 상속받은 클래스를 non-sealed로 지정하였을때 확장이 가능한 점 등을 고려하면 이점을 찾지 못했습니다. 
- 나중에 필요한 상황이오면 sealed class를 이용해보겠습니다.

## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [X] base, compare branch가 적절하게 선택되었나요?
- [X] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)