### PR TITLE
Access Token 재발급하기

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -1,8 +1,9 @@
 == *Auth*
 
+'''
+
 === Login
 
-'''
 ==== Request
 include::{snippets}/auth/login/http-request.adoc[]
 - body
@@ -31,3 +32,22 @@ include::{snippets}/auth/logout/request-cookies.adoc[]
 include::{snippets}/auth/logout/http-response.adoc[]
 - header
 include::{snippets}/auth/logout/response-headers.adoc[]
+
+
+'''
+
+=== Access Token 재발급
+
+==== Request
+include::{snippets}/auth/reissue-token/http-request.adoc[]
+- cookie
+include::{snippets}/auth/reissue-token/request-cookies.adoc[]
+
+==== Response
+include::{snippets}/auth/reissue-token/http-response.adoc[]
+- body
+include::{snippets}/auth/reissue-token/response-fields.adoc[]
+- header
+include::{snippets}/auth/reissue-token/response-headers.adoc[]
+- cookie
+include::{snippets}/auth/reissue-token/response-cookies.adoc[]

--- a/src/main/java/com/numble/instagram/application/auth/AuthService.java
+++ b/src/main/java/com/numble/instagram/application/auth/AuthService.java
@@ -9,9 +9,12 @@ import com.numble.instagram.domain.user.repository.UserRepository;
 import com.numble.instagram.dto.common.LoginDto;
 import com.numble.instagram.exception.notfound.UserNotFoundException;
 import com.numble.instagram.exception.unauthorized.PasswordMismatchException;
+import com.numble.instagram.exception.unauthorized.RefreshTokenExpiredException;
+import com.numble.instagram.exception.unauthorized.RefreshTokenNotExistsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +26,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
+    @Transactional
     public LoginDto login(String nickname, String password) {
         User loginUser = userRepository.findByNickname(nickname)
                 .orElseThrow(UserNotFoundException::new);
@@ -35,5 +39,28 @@ public class AuthService {
         RefreshToken refreshToken = refreshTokenProvider.createToken(userId);
         refreshTokenRepository.save(refreshToken);
         return LoginDto.create(accessToken, refreshToken.tokenValue());
+    }
+
+    @Transactional
+    public LoginDto reissueToken(String refreshTokenValue) {
+        RefreshToken refreshToken = refreshTokenRepository.findTokenByTokenValue(refreshTokenValue)
+                .orElseThrow(RefreshTokenNotExistsException::new);
+
+        validateExpired(refreshToken);
+
+        Long userId = refreshToken.userId();
+        String newAccessToken = tokenProvider.createAccessToken(userId);
+        RefreshToken newRefreshToken = refreshTokenProvider.createToken(userId);
+
+        refreshTokenRepository.delete(refreshTokenValue);
+        refreshTokenRepository.save(newRefreshToken);
+        return LoginDto.create(newAccessToken, newRefreshToken.tokenValue());
+    }
+
+    private void validateExpired(RefreshToken refreshToken) {
+        if (refreshToken.isExpired()) {
+            refreshTokenRepository.delete(refreshToken.tokenValue());
+            throw new RefreshTokenExpiredException();
+        }
     }
 }

--- a/src/main/java/com/numble/instagram/config/WebConfig.java
+++ b/src/main/java/com/numble/instagram/config/WebConfig.java
@@ -1,6 +1,6 @@
 package com.numble.instagram.config;
 
-import com.numble.instagram.presentation.auth.AuthenticatedMemberResolver;
+import com.numble.instagram.presentation.auth.AuthenticatedUserResolver;
 import com.numble.instagram.presentation.auth.AuthenticationInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -21,13 +21,13 @@ import static org.springframework.http.HttpHeaders.SET_COOKIE;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final AuthenticatedMemberResolver authenticatedMemberResolver;
+    private final AuthenticatedUserResolver authenticatedUserResolver;
     private final AuthenticationInterceptor authenticationInterceptor;
     private final static String FRONT_END_LOCAL = "http://localhost:3000";
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(authenticatedMemberResolver);
+        resolvers.add(authenticatedUserResolver);
     }
 
     @Override

--- a/src/main/java/com/numble/instagram/dto/response/auth/AccessTokenResponse.java
+++ b/src/main/java/com/numble/instagram/dto/response/auth/AccessTokenResponse.java
@@ -1,0 +1,7 @@
+package com.numble.instagram.dto.response.auth;
+
+public record AccessTokenResponse(String accessToken) {
+    public static AccessTokenResponse from(String accessToken) {
+        return new AccessTokenResponse(accessToken);
+    }
+}

--- a/src/main/java/com/numble/instagram/dto/response/auth/LoginResponse.java
+++ b/src/main/java/com/numble/instagram/dto/response/auth/LoginResponse.java
@@ -1,7 +1,0 @@
-package com.numble.instagram.dto.response.auth;
-
-public record LoginResponse(String accessToken) {
-    public static LoginResponse from(String accessToken) {
-        return new LoginResponse(accessToken);
-    }
-}

--- a/src/main/java/com/numble/instagram/exception/unauthorized/RefreshTokenExpiredException.java
+++ b/src/main/java/com/numble/instagram/exception/unauthorized/RefreshTokenExpiredException.java
@@ -1,0 +1,8 @@
+package com.numble.instagram.exception.unauthorized;
+
+public class RefreshTokenExpiredException extends UnauthorizedException {
+
+    public RefreshTokenExpiredException() {
+        addValidation("refreshToken", "토큰이 만료되었습니다.");
+    }
+}

--- a/src/main/java/com/numble/instagram/presentation/auth/AuthController.java
+++ b/src/main/java/com/numble/instagram/presentation/auth/AuthController.java
@@ -49,6 +49,7 @@ public class AuthController {
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .body(AccessTokenResponse.from(loginDto.accessToken()));
     }
+
     private void validateRefreshTokenExists(final String refreshToken) {
         if (refreshToken == null) {
             throw new RefreshTokenNotExistsException();

--- a/src/main/java/com/numble/instagram/presentation/auth/AuthController.java
+++ b/src/main/java/com/numble/instagram/presentation/auth/AuthController.java
@@ -3,7 +3,7 @@ package com.numble.instagram.presentation.auth;
 import com.numble.instagram.application.auth.AuthService;
 import com.numble.instagram.dto.common.LoginDto;
 import com.numble.instagram.dto.request.auth.LoginRequest;
-import com.numble.instagram.dto.response.auth.LoginResponse;
+import com.numble.instagram.dto.response.auth.AccessTokenResponse;
 import com.numble.instagram.exception.unauthorized.RefreshTokenNotExistsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -22,22 +22,33 @@ public class AuthController {
     private final RefreshTokenCookieProvider refreshTokenCookieProvider;
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
+    public ResponseEntity<AccessTokenResponse> login(@RequestBody LoginRequest loginRequest) {
         LoginDto loginDto = authService.login(loginRequest.nickname(), loginRequest.password());
         ResponseCookie cookie = refreshTokenCookieProvider.createCookie(loginDto.refreshToken());
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .body(LoginResponse.from(loginDto.accessToken()));
+                .body(AccessTokenResponse.from(loginDto.accessToken()));
     }
 
     @GetMapping("/logout")
-    public ResponseEntity<Void> logout(@CookieValue(value = REFRESH_TOKEN, required = false) String refreshToken) {
+    public ResponseEntity<Void> logout(
+            @CookieValue(value = REFRESH_TOKEN, required = false) String refreshToken) {
         validateRefreshTokenExists(refreshToken);
         return ResponseEntity.noContent()
                 .header(HttpHeaders.SET_COOKIE, refreshTokenCookieProvider.createLogoutCookie().toString())
                 .build();
     }
 
+    @PostMapping("/reissueToken")
+    public ResponseEntity<AccessTokenResponse> reissueToken(
+            @CookieValue(value = REFRESH_TOKEN, required = false) String refreshToken) {
+        validateRefreshTokenExists(refreshToken);
+        LoginDto loginDto = authService.reissueToken(refreshToken);
+        ResponseCookie cookie = refreshTokenCookieProvider.createCookie(loginDto.refreshToken());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(AccessTokenResponse.from(loginDto.accessToken()));
+    }
     private void validateRefreshTokenExists(final String refreshToken) {
         if (refreshToken == null) {
             throw new RefreshTokenNotExistsException();

--- a/src/main/java/com/numble/instagram/presentation/auth/AuthenticatedUser.java
+++ b/src/main/java/com/numble/instagram/presentation/auth/AuthenticatedUser.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface AuthenticatedMember {
+public @interface AuthenticatedUser {
 }

--- a/src/main/java/com/numble/instagram/presentation/auth/AuthenticatedUserResolver.java
+++ b/src/main/java/com/numble/instagram/presentation/auth/AuthenticatedUserResolver.java
@@ -14,13 +14,13 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
 @RequiredArgsConstructor
-public class AuthenticatedMemberResolver implements HandlerMethodArgumentResolver {
+public class AuthenticatedUserResolver implements HandlerMethodArgumentResolver {
 
     private final TokenProvider tokenProvider;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(AuthenticatedMember.class);
+        return parameter.hasParameterAnnotation(AuthenticatedUser.class);
     }
 
     @Override

--- a/src/test/java/com/numble/instagram/presentation/auth/AuthControllerDocsTest.java
+++ b/src/test/java/com/numble/instagram/presentation/auth/AuthControllerDocsTest.java
@@ -121,4 +121,36 @@ class AuthControllerDocsTest {
                         )
                 ));
     }
+
+    @Test
+    @DisplayName("reissue 요청시 토큰을 재발급한다.")
+    void reissueToken() throws Exception {
+        String refreshToken = "valid_refresh_token";
+        String newRefreshToken = "new_refresh_token";
+        LoginDto loginDto = new LoginDto("new_access_token", newRefreshToken);
+        when(authService.reissueToken(refreshToken)).thenReturn(loginDto);
+
+        mockMvc.perform(post("/api/auth/reissueToken")
+                        .cookie(new Cookie("refreshToken", refreshToken)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().value("refreshToken", newRefreshToken))
+                .andExpect(cookie().maxAge("refreshToken", 604800))
+                .andExpect(cookie().httpOnly("refreshToken", true))
+                .andExpect(cookie().secure("refreshToken", true))
+                .andExpect(cookie().path("refreshToken", "/"))
+                .andDo(document(DOCUMENT_IDENTIFIER,
+                        requestCookies(
+                                cookieWithName("refreshToken").description("Refresh Token cookie")
+                        ),
+                        responseFields(
+                                fieldWithPath("accessToken").description("Access Token")
+                        ),
+                        responseHeaders(
+                                headerWithName("Set-Cookie").description("Refresh Token header")
+                        ),
+                        responseCookies(
+                                cookieWithName("refreshToken").description("Refresh Token cookie")
+                        )
+                ));
+    }
 }

--- a/src/test/java/com/numble/instagram/presentation/auth/AuthControllerTest.java
+++ b/src/test/java/com/numble/instagram/presentation/auth/AuthControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -21,6 +22,13 @@ class AuthControllerTest {
     @DisplayName("logout시 쿠키에 리프레쉬 토큰이 없으면 401 에러코드를 던진다.")
     void shouldThrowRefreshTokenNotExistsExceptionWhenRefreshTokenNotProvided() throws Exception {
         mockMvc.perform(get("/api/auth/logout"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 시 쿠키에 리프레쉬 토큰이 없으면 401 에러코드를 던진다.")
+    void shouldThrowRefreshTokenNotExistsExceptionWhenRefreshTokenNotProvided2() throws Exception {
+        mockMvc.perform(post("/api/auth/reissueToken"))
                 .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/com/numble/instagram/presentation/auth/AuthenticatedUserResolverTest.java
+++ b/src/test/java/com/numble/instagram/presentation/auth/AuthenticatedUserResolverTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class AuthenticatedMemberResolverTest {
+public class AuthenticatedUserResolverTest {
 
     @Mock
     private TokenProvider tokenProvider;
@@ -25,17 +25,17 @@ public class AuthenticatedMemberResolverTest {
     private MethodParameter parameter;
     @Mock
     private NativeWebRequest webRequest;
-    private AuthenticatedMemberResolver resolver;
+    private AuthenticatedUserResolver resolver;
 
     @BeforeEach
     void setUp() {
-        resolver = new AuthenticatedMemberResolver(tokenProvider);
+        resolver = new AuthenticatedUserResolver(tokenProvider);
     }
 
     @Test
     @DisplayName("AuthenticatedMember 파라미터 어노테이션이 있으면 true를 반환한다.")
     void testSupportsParameter_shouldReturnTrueWhenParameterHasAuthenticatedMemberAnnotation() {
-        when(parameter.hasParameterAnnotation(AuthenticatedMember.class)).thenReturn(true);
+        when(parameter.hasParameterAnnotation(AuthenticatedUser.class)).thenReturn(true);
 
         boolean result = resolver.supportsParameter(parameter);
 
@@ -45,7 +45,7 @@ public class AuthenticatedMemberResolverTest {
     @Test
     @DisplayName(("AuthenticatedMember 파라미터 어노테이션이 없으면 false를 반환한다."))
     void testSupportsParameter_shouldReturnFalseWhenParameterDoesNotHaveAuthenticatedMemberAnnotation() {
-        when(parameter.hasParameterAnnotation(AuthenticatedMember.class)).thenReturn(false);
+        when(parameter.hasParameterAnnotation(AuthenticatedUser.class)).thenReturn(false);
 
         boolean result = resolver.supportsParameter(parameter);
 


### PR DESCRIPTION
## 작업 주제

- Access Token 재발급하기

## optional 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- Refresh Token으로 Access Token을 재발급 하는 과정을 구현했습니다. 
- Refresh Token의 탈취를 방지하기 위해서 Refresh Token으로 Access Token을 재발급시 Refresh Token도 새로 발급하는 과정이 있습니다.

## optional 추가 코멘트

- [Jwt 과정을 다시 정리하면서 쓴 블로그 글 입니다.](https://biotea.tistory.com/15)

## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [ ] base, compare branch가 적절하게 선택되었나요?
- [ ] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)