### PR TITLE
팔로우, 팔로우 취소 기능

### DIFF
--- a/src/docs/asciidoc/follow.adoc
+++ b/src/docs/asciidoc/follow.adoc
@@ -15,3 +15,19 @@ include::{snippets}/follow/follow/path-parameters.adoc[]
 include::{snippets}/follow/follow/http-response.adoc[]
 - body
 include::{snippets}/follow/follow/response-fields.adoc[]
+
+'''
+
+=== 언팔로우
+
+==== Request
+include::{snippets}/follow/unfollow/http-request.adoc[]
+
+- path parameter
+
+include::{snippets}/follow/unfollow/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/follow/unfollow/http-response.adoc[]
+- body
+include::{snippets}/follow/unfollow/response-fields.adoc[]

--- a/src/docs/asciidoc/follow.adoc
+++ b/src/docs/asciidoc/follow.adoc
@@ -1,0 +1,17 @@
+== *Follow*
+
+'''
+
+=== 팔로우
+
+==== Request
+include::{snippets}/follow/follow/http-request.adoc[]
+
+- path parameter
+
+include::{snippets}/follow/follow/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/follow/follow/http-response.adoc[]
+- body
+include::{snippets}/follow/follow/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -9,3 +9,5 @@
 include::auth.adoc[]
 
 include::user.adoc[]
+
+include::follow.adoc[]

--- a/src/main/java/com/numble/instagram/application/usecase/CreateFollowUserUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/CreateFollowUserUsecase.java
@@ -1,0 +1,21 @@
+package com.numble.instagram.application.usecase;
+
+import com.numble.instagram.domain.follow.service.FollowWriteService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CreateFollowUserUsecase {
+
+    private final UserReadService userReadService;
+    private final FollowWriteService followWriteService;
+
+    public void execute(Long fromUserId, Long toUserId) {
+        User fromUser = userReadService.getUser(fromUserId);
+        User toUser = userReadService.getUser(toUserId);
+        followWriteService.follow(fromUser, toUser);
+    }
+}

--- a/src/main/java/com/numble/instagram/application/usecase/CreateFollowUserUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/CreateFollowUserUsecase.java
@@ -13,9 +13,9 @@ public class CreateFollowUserUsecase {
     private final UserReadService userReadService;
     private final FollowWriteService followWriteService;
 
-    public void execute(Long fromUserId, Long toUserId) {
+    public Long execute(Long fromUserId, Long toUserId) {
         User fromUser = userReadService.getUser(fromUserId);
         User toUser = userReadService.getUser(toUserId);
-        followWriteService.follow(fromUser, toUser);
+        return followWriteService.follow(fromUser, toUser).getToUser().getId();
     }
 }

--- a/src/main/java/com/numble/instagram/application/usecase/DestroyFollowUserUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/DestroyFollowUserUsecase.java
@@ -1,0 +1,21 @@
+package com.numble.instagram.application.usecase;
+
+import com.numble.instagram.domain.follow.service.FollowWriteService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DestroyFollowUserUsecase {
+
+    private final UserReadService userReadService;
+    private final FollowWriteService followWriteService;
+
+    public Long execute(Long fromUserId, Long toUserId) {
+        User fromUser = userReadService.getUser(fromUserId);
+        User toUser = userReadService.getUser(toUserId);
+        return followWriteService.unfollow(fromUser, toUser);
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/follow/entity/Follow.java
+++ b/src/main/java/com/numble/instagram/domain/follow/entity/Follow.java
@@ -2,6 +2,7 @@ package com.numble.instagram.domain.follow.entity;
 
 import com.numble.instagram.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -36,5 +37,15 @@ public class Follow {
     @PrePersist
     private void onPrePersist() {
         this.followedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public Follow(User fromUser, User toUser) {
+        this.fromUser = fromUser;
+        this.toUser = toUser;
+    }
+
+    public static Follow create(User fromUser, User toUser) {
+        return Follow.builder().fromUser(fromUser).toUser(toUser).build();
     }
 }

--- a/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
@@ -1,7 +1,12 @@
 package com.numble.instagram.domain.follow.repository;
 
 import com.numble.instagram.domain.follow.entity.Follow;
+import com.numble.instagram.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    Optional<Follow> findByFromUserAndToUser(User fromUser, User toUser);
 }

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
@@ -4,6 +4,7 @@ import com.numble.instagram.domain.follow.entity.Follow;
 import com.numble.instagram.domain.follow.repository.FollowRepository;
 import com.numble.instagram.domain.user.entity.User;
 import com.numble.instagram.exception.badrequest.AlreadyFollowedUserException;
+import com.numble.instagram.exception.badrequest.NotFollowedUserException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +22,14 @@ public class FollowWriteService {
         checkFollowed(fromUser, toUser);
         Follow follow = Follow.create(fromUser, toUser);
         return followRepository.save(follow);
+    }
+
+    public Long unfollow(User fromUser, User toUser) {
+        Follow followedFollow = followRepository.findByFromUserAndToUser(fromUser, toUser)
+                .orElseThrow(NotFollowedUserException::new);
+        Long toUserId = toUser.getId();
+        followRepository.delete(followedFollow);
+        return toUserId;
     }
 
     private void checkFollowed(User fromUser, User toUser) {

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
@@ -14,8 +14,8 @@ public class FollowWriteService {
 
     private final FollowRepository followRepository;
 
-    public void follow(User fromUser, User toUser) {
+    public Follow follow(User fromUser, User toUser) {
         Follow follow = Follow.create(fromUser, toUser);
-        followRepository.save(follow);
+        return followRepository.save(follow);
     }
 }

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
@@ -1,0 +1,21 @@
+package com.numble.instagram.domain.follow.service;
+
+import com.numble.instagram.domain.follow.entity.Follow;
+import com.numble.instagram.domain.follow.repository.FollowRepository;
+import com.numble.instagram.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FollowWriteService {
+
+    private final FollowRepository followRepository;
+
+    public void follow(User fromUser, User toUser) {
+        Follow follow = Follow.create(fromUser, toUser);
+        followRepository.save(follow);
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
@@ -3,9 +3,12 @@ package com.numble.instagram.domain.follow.service;
 import com.numble.instagram.domain.follow.entity.Follow;
 import com.numble.instagram.domain.follow.repository.FollowRepository;
 import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.exception.badrequest.AlreadyFollowedUserException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,7 +18,16 @@ public class FollowWriteService {
     private final FollowRepository followRepository;
 
     public Follow follow(User fromUser, User toUser) {
+        checkFollowed(fromUser, toUser);
         Follow follow = Follow.create(fromUser, toUser);
         return followRepository.save(follow);
+    }
+
+    private void checkFollowed(User fromUser, User toUser) {
+        Optional<Follow> optionalFollow = followRepository.findByFromUserAndToUser(fromUser, toUser);
+        followRepository.findByFromUserAndToUser(fromUser, toUser);
+        if (optionalFollow.isPresent()) {
+            throw new AlreadyFollowedUserException();
+        }
     }
 }

--- a/src/main/java/com/numble/instagram/domain/user/service/UserReadService.java
+++ b/src/main/java/com/numble/instagram/domain/user/service/UserReadService.java
@@ -1,0 +1,21 @@
+package com.numble.instagram.domain.user.service;
+
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.repository.UserRepository;
+import com.numble.instagram.exception.notfound.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserReadService {
+
+    private final UserRepository userRepository;
+
+    public User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/user/service/UserWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/user/service/UserWriteService.java
@@ -1,14 +1,17 @@
 package com.numble.instagram.domain.user.service;
 
-import com.numble.instagram.support.file.FileStore;
 import com.numble.instagram.domain.user.entity.User;
 import com.numble.instagram.domain.user.repository.UserRepository;
 import com.numble.instagram.dto.request.user.UserJoinRequest;
 import com.numble.instagram.dto.response.user.UserResponse;
+import com.numble.instagram.exception.badrequest.DuplicatedUserException;
+import com.numble.instagram.support.file.FileStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,10 +23,18 @@ public class UserWriteService {
     private final FileStore fileStore;
 
     public UserResponse join(UserJoinRequest userJoinRequest) {
+        validateDuplicateNickname(userJoinRequest.nickname());
         String encodedPassword = passwordEncoder.encode(userJoinRequest.password());
         String profileImageUrl = fileStore.uploadImage(userJoinRequest.profileImageFile());
         User newUser = User.create(userJoinRequest.nickname(), encodedPassword, profileImageUrl);
         userRepository.save(newUser);
         return UserResponse.create(newUser);
+    }
+
+    private void validateDuplicateNickname(String nickname) {
+        Optional<User> DuplicatedUser = userRepository.findByNickname(nickname);
+        if (DuplicatedUser.isPresent()) {
+            throw new DuplicatedUserException();
+        }
     }
 }

--- a/src/main/java/com/numble/instagram/dto/common/FollowDto.java
+++ b/src/main/java/com/numble/instagram/dto/common/FollowDto.java
@@ -1,0 +1,8 @@
+package com.numble.instagram.dto.common;
+
+public record FollowDto(Long userId) {
+
+    public static FollowDto from(Long userId) {
+        return new FollowDto(userId);
+    }
+}

--- a/src/main/java/com/numble/instagram/dto/response/ErrorResponse.java
+++ b/src/main/java/com/numble/instagram/dto/response/ErrorResponse.java
@@ -12,4 +12,8 @@ public record ErrorResponse(int code, String message, Map<String, String> valida
         this.message = message;
         this.validation = validation != null ? validation : Map.of();
     }
+
+    public void addValidation(String fieldName, String errorMessage) {
+        this.validation.put(fieldName, errorMessage);
+    }
 }

--- a/src/main/java/com/numble/instagram/dto/response/ErrorResponse.java
+++ b/src/main/java/com/numble/instagram/dto/response/ErrorResponse.java
@@ -3,6 +3,7 @@ package com.numble.instagram.dto.response;
 import lombok.Builder;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public record ErrorResponse(int code, String message, Map<String, String> validation) {
 
@@ -10,7 +11,7 @@ public record ErrorResponse(int code, String message, Map<String, String> valida
     public ErrorResponse(int code, String message, Map<String, String> validation) {
         this.code = code;
         this.message = message;
-        this.validation = validation != null ? validation : Map.of();
+        this.validation = validation != null ? validation : new ConcurrentHashMap<>();
     }
 
     public void addValidation(String fieldName, String errorMessage) {

--- a/src/main/java/com/numble/instagram/exception/badrequest/AlreadyFollowedUserException.java
+++ b/src/main/java/com/numble/instagram/exception/badrequest/AlreadyFollowedUserException.java
@@ -1,0 +1,8 @@
+package com.numble.instagram.exception.badrequest;
+
+public class AlreadyFollowedUserException extends InvalidRequestException {
+
+    public AlreadyFollowedUserException() {
+        addValidation("toUserId", "이미 팔로우한 유저입니다.");
+    }
+}

--- a/src/main/java/com/numble/instagram/exception/badrequest/DuplicatedUserException.java
+++ b/src/main/java/com/numble/instagram/exception/badrequest/DuplicatedUserException.java
@@ -1,0 +1,8 @@
+package com.numble.instagram.exception.badrequest;
+
+public class DuplicatedUserException extends InvalidRequestException {
+
+    public DuplicatedUserException() {
+        addValidation("nickname", "중복된 닉네임이 존재합니다.");
+    }
+}

--- a/src/main/java/com/numble/instagram/exception/badrequest/NotFollowedUserException.java
+++ b/src/main/java/com/numble/instagram/exception/badrequest/NotFollowedUserException.java
@@ -1,0 +1,8 @@
+package com.numble.instagram.exception.badrequest;
+
+public class NotFollowedUserException extends InvalidRequestException {
+
+    public NotFollowedUserException() {
+        addValidation("toUserId", "팔로우 한 유저가 아닙니다.");
+    }
+}

--- a/src/main/java/com/numble/instagram/presentation/CommonControllerAdvice.java
+++ b/src/main/java/com/numble/instagram/presentation/CommonControllerAdvice.java
@@ -4,14 +4,21 @@ import com.numble.instagram.dto.response.ErrorResponse;
 import com.numble.instagram.exception.CustomException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Slf4j
 @RestControllerAdvice
 public class CommonControllerAdvice {
 
     private static final String LOG_FORMAT = "Body={}";
+    private static final String INVALID_REQUEST_MESSAGE = "잘못된 요청입니다.";
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> customException(CustomException e) {
@@ -25,5 +32,36 @@ public class CommonControllerAdvice {
 
         log.info(LOG_FORMAT, body, e);
         return ResponseEntity.status(statusCode).body(body);
+    }
+
+    @ResponseStatus(BAD_REQUEST)
+    @ExceptionHandler({
+            BindException.class,
+            MethodArgumentNotValidException.class
+    })
+    public ErrorResponse invalidRequestHandler(BindException e) {
+        ErrorResponse body = ErrorResponse.builder()
+                .code(400)
+                .message(INVALID_REQUEST_MESSAGE)
+                .build();
+
+        e.getFieldErrors().forEach((fieldError) ->
+                body.addValidation(fieldError.getField(), fieldError.getDefaultMessage()));
+
+        log.info(LOG_FORMAT, body, e);
+        return body;
+    }
+
+    @ResponseStatus(INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(RuntimeException.class)
+    public ErrorResponse handleInternalServerError(RuntimeException e) {
+
+        ErrorResponse body = ErrorResponse.builder()
+                .code(500)
+                .message(e.getMessage())
+                .build();
+
+        log.error("RuntimeException ", e);
+        return body;
     }
 }

--- a/src/main/java/com/numble/instagram/presentation/follow/FollowController.java
+++ b/src/main/java/com/numble/instagram/presentation/follow/FollowController.java
@@ -1,6 +1,7 @@
 package com.numble.instagram.presentation.follow;
 
 import com.numble.instagram.application.usecase.CreateFollowUserUsecase;
+import com.numble.instagram.application.usecase.DestroyFollowUserUsecase;
 import com.numble.instagram.dto.common.FollowDto;
 import com.numble.instagram.presentation.auth.AuthenticatedUser;
 import com.numble.instagram.presentation.auth.Login;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class FollowController {
 
     private final CreateFollowUserUsecase createFollowUserUsecase;
+    private final DestroyFollowUserUsecase destroyFollowUserUsecase;
 
     @Login
     @PostMapping("/{toUserId}")
@@ -23,5 +25,13 @@ public class FollowController {
                             @PathVariable Long toUserId) {
         Long savedToUserId = createFollowUserUsecase.execute(fromUserId, toUserId);
         return FollowDto.from(savedToUserId);
+    }
+
+    @Login
+    @PostMapping("/unfollow/{toUserId}")
+    public FollowDto unfollow(@AuthenticatedUser Long fromUserId,
+                            @PathVariable Long toUserId) {
+        Long deletedToUserId = destroyFollowUserUsecase.execute(fromUserId, toUserId);
+        return FollowDto.from(deletedToUserId);
     }
 }

--- a/src/main/java/com/numble/instagram/presentation/follow/FollowController.java
+++ b/src/main/java/com/numble/instagram/presentation/follow/FollowController.java
@@ -21,7 +21,7 @@ public class FollowController {
     @PostMapping("/{toUserId}")
     public FollowDto follow(@AuthenticatedUser Long fromUserId,
                             @PathVariable Long toUserId) {
-        createFollowUserUsecase.execute(fromUserId, toUserId);
-        return FollowDto.from(toUserId);
+        Long savedToUserId = createFollowUserUsecase.execute(fromUserId, toUserId);
+        return FollowDto.from(savedToUserId);
     }
 }

--- a/src/main/java/com/numble/instagram/presentation/follow/FollowController.java
+++ b/src/main/java/com/numble/instagram/presentation/follow/FollowController.java
@@ -1,0 +1,27 @@
+package com.numble.instagram.presentation.follow;
+
+import com.numble.instagram.application.usecase.CreateFollowUserUsecase;
+import com.numble.instagram.dto.common.FollowDto;
+import com.numble.instagram.presentation.auth.AuthenticatedUser;
+import com.numble.instagram.presentation.auth.Login;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/follow")
+public class FollowController {
+
+    private final CreateFollowUserUsecase createFollowUserUsecase;
+
+    @Login
+    @PostMapping("/{toUserId}")
+    public FollowDto follow(@AuthenticatedUser Long fromUserId,
+                            @PathVariable Long toUserId) {
+        createFollowUserUsecase.execute(fromUserId, toUserId);
+        return FollowDto.from(toUserId);
+    }
+}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -15,7 +15,10 @@ spring.sql.init.mode=always
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.open-in-view=true
 spring.jpa.hibernate.ddl-auto=create-drop
+
+logging.level.org.springframework.core.LocalVariableTableParameterNameDiscoverer = error
 
 # jwt token properties
 jwt.token.secret=LocalJno9KUpS2rn+Hvvuyt9LudmuagIMueMkvxR4dH5I=

--- a/src/test/java/com/numble/instagram/domain/follow/service/FollowWriteServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/follow/service/FollowWriteServiceTest.java
@@ -4,6 +4,7 @@ import com.numble.instagram.domain.follow.entity.Follow;
 import com.numble.instagram.domain.follow.repository.FollowRepository;
 import com.numble.instagram.domain.user.entity.User;
 import com.numble.instagram.exception.badrequest.AlreadyFollowedUserException;
+import com.numble.instagram.exception.badrequest.NotFollowedUserException;
 import com.numble.instagram.util.fixture.follow.FollowFixture;
 import com.numble.instagram.util.fixture.user.UserFixture;
 import org.junit.jupiter.api.DisplayName;
@@ -53,5 +54,28 @@ class FollowWriteServiceTest {
         when(followRepository.findByFromUserAndToUser(fromUser, toUser)).thenReturn(Optional.of(alreadyFollowedFollow));
 
         assertThrows(AlreadyFollowedUserException.class, () -> followWriteService.follow(fromUser, toUser));
+    }
+
+    @Test
+    @DisplayName("언팔로우가 완료되어야 한다.")
+    void unfollow() {
+        User fromUser = UserFixture.create(1L, "user1");
+        User toUser = UserFixture.create(2L, "user2");
+        Follow followedFollow = FollowFixture.create(fromUser, toUser);
+
+        when(followRepository.findByFromUserAndToUser(fromUser, toUser)).thenReturn(Optional.of(followedFollow));
+
+        Long result = followWriteService.unfollow(fromUser, toUser);
+        assertEquals(toUser.getId(), result);
+    }
+
+    @Test
+    @DisplayName("팔로우가 아니면 언팔로우 할 수 없다.")
+    void followedWillNotUnfollow() {
+        User fromUser = UserFixture.create(1L, "user1");
+        User toUser = UserFixture.create(2L, "user2");
+
+        when(followRepository.findByFromUserAndToUser(fromUser, toUser)).thenReturn(Optional.empty());
+        assertThrows(NotFollowedUserException.class, () -> followWriteService.unfollow(fromUser, toUser));
     }
 }

--- a/src/test/java/com/numble/instagram/domain/follow/service/FollowWriteServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/follow/service/FollowWriteServiceTest.java
@@ -3,6 +3,7 @@ package com.numble.instagram.domain.follow.service;
 import com.numble.instagram.domain.follow.entity.Follow;
 import com.numble.instagram.domain.follow.repository.FollowRepository;
 import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.exception.badrequest.AlreadyFollowedUserException;
 import com.numble.instagram.util.fixture.follow.FollowFixture;
 import com.numble.instagram.util.fixture.user.UserFixture;
 import org.junit.jupiter.api.DisplayName;
@@ -12,7 +13,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -27,7 +31,7 @@ class FollowWriteServiceTest {
 
     @Test
     @DisplayName("팔로우는 완료 되어야 한다. ")
-    public void followTest() {
+    void followTest() {
         User fromUser = UserFixture.create(1L, "user1");
         User toUser = UserFixture.create(2L, "user2");
         Follow follow = FollowFixture.create(fromUser, toUser);
@@ -37,5 +41,17 @@ class FollowWriteServiceTest {
         Follow savedFollow = followWriteService.follow(fromUser, toUser);
 
         assertEquals(follow, savedFollow);
+    }
+
+    @Test
+    @DisplayName("이미 팔로우 했으면 발생한다.")
+    void follow_AlreadyFollowed() {
+        User fromUser = UserFixture.create(1L, "user1");
+        User toUser = UserFixture.create(2L, "user2");
+        Follow alreadyFollowedFollow = FollowFixture.create(fromUser, toUser);
+
+        when(followRepository.findByFromUserAndToUser(fromUser, toUser)).thenReturn(Optional.of(alreadyFollowedFollow));
+
+        assertThrows(AlreadyFollowedUserException.class, () -> followWriteService.follow(fromUser, toUser));
     }
 }

--- a/src/test/java/com/numble/instagram/domain/follow/service/FollowWriteServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/follow/service/FollowWriteServiceTest.java
@@ -1,0 +1,41 @@
+package com.numble.instagram.domain.follow.service;
+
+import com.numble.instagram.domain.follow.entity.Follow;
+import com.numble.instagram.domain.follow.repository.FollowRepository;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.util.fixture.follow.FollowFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FollowWriteServiceTest {
+
+    @InjectMocks
+    private FollowWriteService followWriteService;
+
+    @Mock
+    private FollowRepository followRepository;
+
+    @Test
+    @DisplayName("팔로우는 완료 되어야 한다. ")
+    public void followTest() {
+        User fromUser = UserFixture.create(1L, "user1");
+        User toUser = UserFixture.create(2L, "user2");
+        Follow follow = FollowFixture.create(fromUser, toUser);
+
+        when(followRepository.save(any(Follow.class))).thenReturn(follow);
+
+        Follow savedFollow = followWriteService.follow(fromUser, toUser);
+
+        assertEquals(follow, savedFollow);
+    }
+}

--- a/src/test/java/com/numble/instagram/presentation/follow/FollowControllerDocTest.java
+++ b/src/test/java/com/numble/instagram/presentation/follow/FollowControllerDocTest.java
@@ -1,6 +1,7 @@
 package com.numble.instagram.presentation.follow;
 
 import com.numble.instagram.application.usecase.CreateFollowUserUsecase;
+import com.numble.instagram.application.usecase.DestroyFollowUserUsecase;
 import com.numble.instagram.presentation.auth.AuthenticatedUserResolver;
 import com.numble.instagram.presentation.auth.AuthenticationInterceptor;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,6 +44,8 @@ class FollowControllerDocTest {
     @MockBean
     private CreateFollowUserUsecase createFollowUserUsecase;
     @MockBean
+    private DestroyFollowUserUsecase destroyFollowUserUsecase;
+    @MockBean
     private AuthenticationInterceptor interceptor;
     @MockBean
     private AuthenticatedUserResolver authenticatedUserResolver;
@@ -66,6 +69,31 @@ class FollowControllerDocTest {
     @Test
     @DisplayName("팔로우는 완료되어야 한다.")
     void follow() throws Exception {
+        Long fromUserId = 1L;
+        Long toUserId = 2L;
+
+        when(authenticatedUserResolver.supportsParameter(any())).thenReturn(true);
+        when(authenticatedUserResolver.resolveArgument(any(),any(),any(),any())).thenReturn(fromUserId);
+        given(destroyFollowUserUsecase.execute(eq(fromUserId), eq(toUserId))).willReturn(toUserId);
+
+        mockMvc.perform(post("/api/follow/unfollow/{toUserId}", toUserId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer access-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(toUserId))
+                .andDo(print())
+                .andDo(document(DOCUMENT_IDENTIFIER,
+                        pathParameters(
+                                parameterWithName("toUserId").description("언팔로우 할 유저 id")
+                        ),
+                        responseFields(
+                                fieldWithPath("userId").description("언팔로우 한 유저 id")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("언팔로우는 완료되어야 한다.")
+    void unfollow() throws Exception {
         Long fromUserId = 1L;
         Long toUserId = 2L;
 

--- a/src/test/java/com/numble/instagram/presentation/follow/FollowControllerDocTest.java
+++ b/src/test/java/com/numble/instagram/presentation/follow/FollowControllerDocTest.java
@@ -64,15 +64,15 @@ class FollowControllerDocTest {
                 .build();
 
         when(interceptor.preHandle(any(),any(),any())).thenReturn(true);
+        when(authenticatedUserResolver.supportsParameter(any())).thenReturn(true);
     }
 
     @Test
-    @DisplayName("팔로우는 완료되어야 한다.")
-    void follow() throws Exception {
+    @DisplayName("언팔로우는 완료되어야 한다.")
+    void unfollow() throws Exception {
         Long fromUserId = 1L;
         Long toUserId = 2L;
 
-        when(authenticatedUserResolver.supportsParameter(any())).thenReturn(true);
         when(authenticatedUserResolver.resolveArgument(any(),any(),any(),any())).thenReturn(fromUserId);
         given(destroyFollowUserUsecase.execute(eq(fromUserId), eq(toUserId))).willReturn(toUserId);
 
@@ -92,12 +92,11 @@ class FollowControllerDocTest {
     }
 
     @Test
-    @DisplayName("언팔로우는 완료되어야 한다.")
-    void unfollow() throws Exception {
+    @DisplayName("팔로우는 완료되어야 한다.")
+    void follow() throws Exception {
         Long fromUserId = 1L;
         Long toUserId = 2L;
 
-        when(authenticatedUserResolver.supportsParameter(any())).thenReturn(true);
         when(authenticatedUserResolver.resolveArgument(any(),any(),any(),any())).thenReturn(fromUserId);
         given(createFollowUserUsecase.execute(eq(fromUserId), eq(toUserId))).willReturn(toUserId);
 

--- a/src/test/java/com/numble/instagram/presentation/follow/FollowControllerDocTest.java
+++ b/src/test/java/com/numble/instagram/presentation/follow/FollowControllerDocTest.java
@@ -1,0 +1,90 @@
+package com.numble.instagram.presentation.follow;
+
+import com.numble.instagram.application.usecase.CreateFollowUserUsecase;
+import com.numble.instagram.presentation.auth.AuthenticatedUserResolver;
+import com.numble.instagram.presentation.auth.AuthenticationInterceptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
+class FollowControllerDocTest {
+
+    private MockMvc mockMvc;
+    @MockBean
+    private CreateFollowUserUsecase createFollowUserUsecase;
+    @MockBean
+    private AuthenticationInterceptor interceptor;
+    @MockBean
+    private AuthenticatedUserResolver authenticatedUserResolver;
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+    private static final String DOCUMENT_IDENTIFIER = "follow/{method-name}/";
+
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint(), modifyHeaders().remove("Vary")))
+                .build();
+
+        when(interceptor.preHandle(any(),any(),any())).thenReturn(true);
+    }
+
+    @Test
+    @DisplayName("팔로우는 완료되어야 한다.")
+    void follow() throws Exception {
+        Long fromUserId = 1L;
+        Long toUserId = 2L;
+
+        when(authenticatedUserResolver.supportsParameter(any())).thenReturn(true);
+        when(authenticatedUserResolver.resolveArgument(any(),any(),any(),any())).thenReturn(fromUserId);
+        given(createFollowUserUsecase.execute(eq(fromUserId), eq(toUserId))).willReturn(toUserId);
+
+        mockMvc.perform(post("/api/follow/{toUserId}", toUserId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer access-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(toUserId))
+                .andDo(print())
+                .andDo(document(DOCUMENT_IDENTIFIER,
+                        pathParameters(
+                                parameterWithName("toUserId").description("팔로우 할 유저 id")
+                        ),
+                        responseFields(
+                                fieldWithPath("userId").description("팔로우 한 유저 id")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/numble/instagram/util/fixture/follow/FollowFixture.java
+++ b/src/test/java/com/numble/instagram/util/fixture/follow/FollowFixture.java
@@ -1,0 +1,11 @@
+package com.numble.instagram.util.fixture.follow;
+
+import com.numble.instagram.domain.follow.entity.Follow;
+import com.numble.instagram.domain.user.entity.User;
+
+public class FollowFixture {
+
+    public static Follow create(User fromUser, User toUser) {
+        return new Follow(fromUser, toUser);
+    }
+}

--- a/src/test/java/com/numble/instagram/util/fixture/user/UserFixture.java
+++ b/src/test/java/com/numble/instagram/util/fixture/user/UserFixture.java
@@ -28,4 +28,25 @@ public class UserFixture {
 
         return new EasyRandom(param).nextObject(User.class);
     }
+
+    public static User create(Long userId, String nickname) {
+        var idPredicate = named("id")
+                .and(ofType(Long.class))
+                .and(inClass(User.class));
+
+        var nicknamePredicate = named("nickname")
+                .and(ofType(String.class))
+                .and(inClass(User.class));
+
+        var passwordPredicate = named("password")
+                .and(ofType(String.class))
+                .and(inClass(User.class));
+
+        var param = new EasyRandomParameters()
+                .randomize(idPredicate, () -> userId)
+                .randomize(nicknamePredicate, () -> nickname)
+                .excludeField(passwordPredicate);
+
+        return new EasyRandom(param).nextObject(User.class);
+    }
 }


### PR DESCRIPTION
## 작업 주제

- 팔로우, 팔로우 취소 기능을 구현했습니다.

## optional 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- Usecase를 도입해서 domain에 다른 domain이 영향을 주지 않도록 고려해서 구현했습니다. 
- CreateFollowUserUsecase 와 DestroyFollowUserUsecase를 이용하여 팔로우와 언팔로우를 구현했습니다.
- Test시 resolver의 헤더값을 mock으로 가져오는데 조금 어려움을 겪었지만 해결했습니다.

## optional 화면 스크린샷

```java
@RequiredArgsConstructor
@Service
public class CreateFollowUserUsecase {

    private final UserReadService userReadService;
    private final FollowWriteService followWriteService;

    public Long execute(Long fromUserId, Long toUserId) {
        User fromUser = userReadService.getUser(fromUserId);
        User toUser = userReadService.getUser(toUserId);
        return followWriteService.follow(fromUser, toUser).getToUser().getId();
    }
}
```
이렇게 sevice layer에서 정보를 가져와 처리하는식으로 구현했습니다.

## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [ ] base, compare branch가 적절하게 선택되었나요?
- [ ] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)