### PR TITLE
프로필 수정, 프로필 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,15 @@ ext {
 }
 
 dependencies {
-	  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	  implementation 'org.springframework.boot:spring-boot-starter-web'
-	  implementation 'org.springframework.security:spring-security-crypto'
-	  implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.security:spring-security-crypto'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation 'com.querydsl:querydsl-jpa'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ dependencies {
     implementation 'org.springframework.security:spring-security-crypto'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-    implementation 'com.querydsl:querydsl-jpa'
-    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
@@ -87,4 +87,18 @@ task dolocal {
         from asciidoctor.outputDir
         into "src/main/resources/static/docs"
     }
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
 }

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -41,3 +41,20 @@ include::{snippets}/user/edit/request-parts.adoc[]
 include::{snippets}/user/edit/http-response.adoc[]
 - body
 include::{snippets}/user/edit/response-fields.adoc[]
+
+
+'''
+
+=== 프로필 조회
+
+==== Request
+include::{snippets}/user/get-user-profile/http-request.adoc[]
+
+- path parameter
+
+include::{snippets}/user/get-user-profile/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/user/get-user-profile/http-request.adoc[]
+- body
+include::{snippets}/user/get-user-profile/response-fields.adoc[]

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -20,3 +20,24 @@ include::{snippets}/user/join/request-parts.adoc[]
 include::{snippets}/user/join/http-response.adoc[]
 - body
 include::{snippets}/user/join/response-fields.adoc[]
+
+'''
+
+=== 프로필 수정
+
+==== Request
+include::{snippets}/user/edit/http-request.adoc[]
+- param
+
+현재 rest-docs 3.0 버전에서 requestParameters를 지원하지 않고 formParameters, queryParameters로 나뉘면서
+multipart 요청시 form-data가 정상적으로 작동하지 않는 현상 때문에 multipart 요청시 parameter를 docs로 만들지 못하고 있습니다.
+
+프로필 수정시 필요한 form-data는 nickname(String) 입니다. 감사합니다.
+
+- part
+include::{snippets}/user/edit/request-parts.adoc[]
+
+==== Response
+include::{snippets}/user/edit/http-response.adoc[]
+- body
+include::{snippets}/user/edit/response-fields.adoc[]

--- a/src/main/java/com/numble/instagram/application/usecase/GetFollowingAndFollowerCountUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/GetFollowingAndFollowerCountUsecase.java
@@ -1,0 +1,24 @@
+package com.numble.instagram.application.usecase;
+
+import com.numble.instagram.domain.follow.service.FollowReadService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.response.user.UserDetailResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class GetFollowingAndFollowerCountUsecase {
+
+    private final UserReadService userReadService;
+    private final FollowReadService followReadService;
+
+    public UserDetailResponse execute(Long userId) {
+        User user = userReadService.getUser(userId);
+        Long followerCount = followReadService.getFollowerCount(userId);
+        Long followingCount = followReadService.getFollowingCount(userId);
+
+        return UserDetailResponse.from(user, followerCount, followingCount);
+    }
+}

--- a/src/main/java/com/numble/instagram/application/usecase/GetUserProfileUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/GetUserProfileUsecase.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
-public class GetFollowingAndFollowerCountUsecase {
+public class GetUserProfileUsecase {
 
     private final UserReadService userReadService;
     private final FollowReadService followReadService;

--- a/src/main/java/com/numble/instagram/config/JpaConfig.java
+++ b/src/main/java/com/numble/instagram/config/JpaConfig.java
@@ -1,0 +1,19 @@
+package com.numble.instagram.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    public EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface FollowRepository extends JpaRepository<Follow, Long> {
+public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRepositoryCustom {
 
     Optional<Follow> findByFromUserAndToUser(User fromUser, User toUser);
 }

--- a/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepositoryCustom.java
+++ b/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.numble.instagram.domain.follow.repository;
+
+public interface FollowRepositoryCustom {
+
+    Long getFollowerCount(Long userId);
+    Long getFollowingCount(Long userId);
+}

--- a/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepositoryImpl.java
+++ b/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.numble.instagram.domain.follow.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static com.numble.instagram.domain.follow.entity.QFollow.follow;
+
+@RequiredArgsConstructor
+public class FollowRepositoryImpl implements FollowRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Long getFollowerCount(Long userId) {
+        return jpaQueryFactory.select(follow.count())
+                .from(follow)
+                .where(follow.toUser.id.eq(userId))
+                .fetchOne();
+    }
+
+    @Override
+    public Long getFollowingCount(Long userId) {
+        return jpaQueryFactory.select(follow.count())
+                .from(follow)
+                .where(follow.fromUser.id.eq(userId))
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
@@ -1,0 +1,22 @@
+package com.numble.instagram.domain.follow.service;
+
+import com.numble.instagram.domain.follow.repository.FollowRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FollowReadService {
+
+    private final FollowRepository followRepository;
+
+    public Long getFollowerCount(Long userId) {
+        return followRepository.getFollowerCount(userId);
+    }
+
+    public Long getFollowingCount(Long userId) {
+        return followRepository.getFollowingCount(userId);
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/user/entity/User.java
+++ b/src/main/java/com/numble/instagram/domain/user/entity/User.java
@@ -50,4 +50,14 @@ public class User {
                 .profileImageUrl(profileImageUrl)
                 .build();
     }
+
+    public void changeNickname(String newNickname) {
+        if (!nickname.equals(newNickname)) {
+            this.nickname = newNickname;
+        }
+    }
+
+    public void changeProfileImageUrl(String newProfileImageUrl) {
+        this.profileImageUrl = newProfileImageUrl;
+    }
 }

--- a/src/main/java/com/numble/instagram/domain/user/service/UserWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/user/service/UserWriteService.java
@@ -33,11 +33,15 @@ public class UserWriteService {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
         user.changeNickname(newNickname);
-        if (!newProfileImageFile.isEmpty()) {
+        checkImageFileAndChange(newProfileImageFile, user);
+        return UserResponse.from(user);
+    }
+
+    private void checkImageFileAndChange(MultipartFile newProfileImageFile, User user) {
+        if (newProfileImageFile == null || !newProfileImageFile.isEmpty()) {
             fileStore.deleteFile(user.getProfileImageUrl());
             String newProfileImageUrl = fileStore.uploadImage(newProfileImageFile);
             user.changeProfileImageUrl(newProfileImageUrl);
         }
-        return UserResponse.from(user);
     }
 }

--- a/src/main/java/com/numble/instagram/domain/user/service/UserWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/user/service/UserWriteService.java
@@ -1,5 +1,6 @@
 package com.numble.instagram.domain.user.service;
 
+import com.numble.instagram.exception.notfound.UserNotFoundException;
 import com.numble.instagram.support.file.FileStore;
 import com.numble.instagram.domain.user.entity.User;
 import com.numble.instagram.domain.user.repository.UserRepository;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +26,18 @@ public class UserWriteService {
         String profileImageUrl = fileStore.uploadImage(userJoinRequest.profileImageFile());
         User newUser = User.create(userJoinRequest.nickname(), encodedPassword, profileImageUrl);
         userRepository.save(newUser);
-        return UserResponse.create(newUser);
+        return UserResponse.from(newUser);
+    }
+
+    public UserResponse edit(Long userId, String newNickname, MultipartFile newProfileImageFile) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        user.changeNickname(newNickname);
+        if (!newProfileImageFile.isEmpty()) {
+            fileStore.deleteFile(user.getProfileImageUrl());
+            String newProfileImageUrl = fileStore.uploadImage(newProfileImageFile);
+            user.changeProfileImageUrl(newProfileImageUrl);
+        }
+        return UserResponse.from(user);
     }
 }

--- a/src/main/java/com/numble/instagram/dto/request/user/UserEditRequest.java
+++ b/src/main/java/com/numble/instagram/dto/request/user/UserEditRequest.java
@@ -3,8 +3,7 @@ package com.numble.instagram.dto.request.user;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.web.multipart.MultipartFile;
 
-public record UserJoinRequest(
+public record UserEditRequest(
         @NotBlank String nickname,
-        @NotBlank String password,
         MultipartFile profileImageFile) {
 }

--- a/src/main/java/com/numble/instagram/dto/response/user/UserDetailResponse.java
+++ b/src/main/java/com/numble/instagram/dto/response/user/UserDetailResponse.java
@@ -1,0 +1,10 @@
+package com.numble.instagram.dto.response.user;
+
+import com.numble.instagram.domain.user.entity.User;
+
+public record UserDetailResponse(String nickname, String profileImageUrl, Long follower, Long following) {
+
+    public static UserDetailResponse from(User user, Long followerCount, Long followingCount) {
+        return new UserDetailResponse(user.getNickname(), user.getProfileImageUrl(), followerCount, followingCount);
+    }
+}

--- a/src/main/java/com/numble/instagram/dto/response/user/UserResponse.java
+++ b/src/main/java/com/numble/instagram/dto/response/user/UserResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 
 public record UserResponse(Long id, String nickname, String profileImageUrl, LocalDateTime joinedAt) {
 
-    public static UserResponse create(User user) {
+    public static UserResponse from(User user) {
         return new UserResponse(user.getId(), user.getNickname(), user.getProfileImageUrl(), user.getJoinedAt());
     }
 }

--- a/src/main/java/com/numble/instagram/presentation/user/UserController.java
+++ b/src/main/java/com/numble/instagram/presentation/user/UserController.java
@@ -8,7 +8,9 @@ import com.numble.instagram.presentation.auth.AuthenticatedUser;
 import com.numble.instagram.presentation.auth.Login;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,7 +27,7 @@ public class UserController {
     @Login
     @PostMapping("/edit")
     public UserResponse edit(@AuthenticatedUser Long userId,
-                             @Validated @RequestBody UserEditRequest userEditRequest) {
+                             @Validated UserEditRequest userEditRequest) {
         return userWriteService.edit(userId, userEditRequest.nickname(), userEditRequest.profileImageFile());
     }
 }

--- a/src/main/java/com/numble/instagram/presentation/user/UserController.java
+++ b/src/main/java/com/numble/instagram/presentation/user/UserController.java
@@ -1,16 +1,16 @@
 package com.numble.instagram.presentation.user;
 
+import com.numble.instagram.application.usecase.GetFollowingAndFollowerCountUsecase;
 import com.numble.instagram.domain.user.service.UserWriteService;
 import com.numble.instagram.dto.request.user.UserEditRequest;
 import com.numble.instagram.dto.request.user.UserJoinRequest;
+import com.numble.instagram.dto.response.user.UserDetailResponse;
 import com.numble.instagram.dto.response.user.UserResponse;
 import com.numble.instagram.presentation.auth.AuthenticatedUser;
 import com.numble.instagram.presentation.auth.Login;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserWriteService userWriteService;
+    private final GetFollowingAndFollowerCountUsecase getFollowingAndFollowerCountUsecase;
 
     @PostMapping
     public UserResponse join(@Validated UserJoinRequest userJoinRequest) {
@@ -29,5 +30,10 @@ public class UserController {
     public UserResponse edit(@AuthenticatedUser Long userId,
                              @Validated UserEditRequest userEditRequest) {
         return userWriteService.edit(userId, userEditRequest.nickname(), userEditRequest.profileImageFile());
+    }
+
+    @GetMapping("/{userId}")
+    public UserDetailResponse get(@PathVariable Long userId) {
+        return getFollowingAndFollowerCountUsecase.execute(userId);
     }
 }

--- a/src/main/java/com/numble/instagram/presentation/user/UserController.java
+++ b/src/main/java/com/numble/instagram/presentation/user/UserController.java
@@ -1,13 +1,14 @@
 package com.numble.instagram.presentation.user;
 
 import com.numble.instagram.domain.user.service.UserWriteService;
+import com.numble.instagram.dto.request.user.UserEditRequest;
 import com.numble.instagram.dto.request.user.UserJoinRequest;
 import com.numble.instagram.dto.response.user.UserResponse;
+import com.numble.instagram.presentation.auth.AuthenticatedUser;
+import com.numble.instagram.presentation.auth.Login;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,5 +20,12 @@ public class UserController {
     @PostMapping
     public UserResponse join(@Validated UserJoinRequest userJoinRequest) {
         return userWriteService.join(userJoinRequest);
+    }
+
+    @Login
+    @PutMapping
+    public UserResponse edit(@AuthenticatedUser Long userId,
+                             @Validated @RequestBody UserEditRequest userEditRequest) {
+        return userWriteService.edit(userId, userEditRequest.nickname(), userEditRequest.profileImageFile());
     }
 }

--- a/src/main/java/com/numble/instagram/presentation/user/UserController.java
+++ b/src/main/java/com/numble/instagram/presentation/user/UserController.java
@@ -23,7 +23,7 @@ public class UserController {
     }
 
     @Login
-    @PutMapping
+    @PostMapping("/edit")
     public UserResponse edit(@AuthenticatedUser Long userId,
                              @Validated @RequestBody UserEditRequest userEditRequest) {
         return userWriteService.edit(userId, userEditRequest.nickname(), userEditRequest.profileImageFile());

--- a/src/main/java/com/numble/instagram/presentation/user/UserController.java
+++ b/src/main/java/com/numble/instagram/presentation/user/UserController.java
@@ -1,6 +1,6 @@
 package com.numble.instagram.presentation.user;
 
-import com.numble.instagram.application.usecase.GetFollowingAndFollowerCountUsecase;
+import com.numble.instagram.application.usecase.GetUserProfileUsecase;
 import com.numble.instagram.domain.user.service.UserWriteService;
 import com.numble.instagram.dto.request.user.UserEditRequest;
 import com.numble.instagram.dto.request.user.UserJoinRequest;
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserWriteService userWriteService;
-    private final GetFollowingAndFollowerCountUsecase getFollowingAndFollowerCountUsecase;
+    private final GetUserProfileUsecase getUserProfileUsecase;
 
     @PostMapping
     public UserResponse join(@Validated UserJoinRequest userJoinRequest) {
@@ -34,6 +34,6 @@ public class UserController {
 
     @GetMapping("/{userId}")
     public UserDetailResponse get(@PathVariable Long userId) {
-        return getFollowingAndFollowerCountUsecase.execute(userId);
+        return getUserProfileUsecase.execute(userId);
     }
 }

--- a/src/main/java/com/numble/instagram/support/file/FileStoreImpl.java
+++ b/src/main/java/com/numble/instagram/support/file/FileStoreImpl.java
@@ -33,7 +33,7 @@ public class FileStoreImpl implements FileStore {
         if (imageUrl.equals(DEFAULT_IMAGE)) {
             return;
         }
-        // TODO delete login;
+        // TODO delete logic;
     }
 
     private static void validateContentTypeImage(MultipartFile multipartFile) {

--- a/src/test/java/com/numble/instagram/domain/follow/service/FollowReadServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/follow/service/FollowReadServiceTest.java
@@ -1,0 +1,67 @@
+package com.numble.instagram.domain.follow.service;
+
+import com.numble.instagram.domain.follow.entity.Follow;
+import com.numble.instagram.domain.follow.repository.FollowRepository;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.repository.UserRepository;
+import com.numble.instagram.util.fixture.follow.FollowFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.LongStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+class FollowReadServiceTest {
+
+    @Autowired
+    private FollowRepository followRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private FollowReadService followReadService;
+
+    @Test
+    @DisplayName("팔로우 한 사람의 수를 가져올 수 있다.")
+    void getFollowingCount() {
+        User user = UserFixture.create("user");
+        userRepository.save(user);
+
+        List<Follow> followings = new LinkedList<>();
+        LongStream.range(1, 20).forEach(i -> {
+            User FollowingUser = UserFixture.create("followingUser");
+            userRepository.saveAndFlush(FollowingUser);
+            followings.add(FollowFixture.create(user, FollowingUser));
+        });
+        followRepository.saveAllAndFlush(followings);
+
+        Long followingCount = followReadService.getFollowingCount(user.getId());
+
+        assertEquals(19L, followingCount);
+    }
+
+    @Test
+    @DisplayName("팔로워의 수를 가져올 수 있다.")
+    void getFollowerCount() {
+        User user = UserFixture.create("user");
+        userRepository.save(user);
+
+        List<Follow> followers = new LinkedList<>();
+        LongStream.range(1, 20).forEach(i -> {
+            User followerUser = UserFixture.create("followerUser");
+            userRepository.save(followerUser);
+            followers.add(FollowFixture.create(followerUser, user));
+        });
+        followRepository.saveAll(followers);
+
+        Long followingCount = followReadService.getFollowerCount(user.getId());
+
+        assertEquals(19L, followingCount);
+    }
+}

--- a/src/test/java/com/numble/instagram/domain/user/entity/UserTest.java
+++ b/src/test/java/com/numble/instagram/domain/user/entity/UserTest.java
@@ -1,0 +1,26 @@
+package com.numble.instagram.domain.user.entity;
+
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UserTest {
+
+    @Test
+    @DisplayName("nickname은 수정되어야한다.")
+    void changeNickname() {
+        User user = UserFixture.create(1L, "oldNickname", "1234");
+        user.changeNickname("newNickname");
+        assertEquals("newNickname", user.getNickname());
+    }
+
+    @Test
+    @DisplayName("같은 nickname은 수정되지않는다.")
+    void changeSameNickname() {
+        User user = UserFixture.create(1L, "oldNickname", "1234");
+        user.changeNickname("oldNickname");
+        assertEquals("oldNickname", user.getNickname());
+    }
+}

--- a/src/test/java/com/numble/instagram/domain/user/service/UserWriteServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/user/service/UserWriteServiceTest.java
@@ -5,12 +5,17 @@ import com.numble.instagram.domain.user.repository.UserRepository;
 import com.numble.instagram.dto.request.user.UserJoinRequest;
 import com.numble.instagram.dto.response.user.UserResponse;
 import com.numble.instagram.support.file.FileStore;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,6 +37,7 @@ class UserWriteServiceTest {
     private FileStore fileStore;
 
     @Test
+    @DisplayName("회원가입은 완료되어야 한다.")
     void join_shouldReturnCreatedUserResponse() {
         UserJoinRequest userJoinRequest = new UserJoinRequest("testuser", "password", null);
         String encodedPassword = "encodedPassword";
@@ -46,5 +52,37 @@ class UserWriteServiceTest {
 
         assertEquals(newUser.getNickname(), userResponse.nickname());
         assertEquals(newUser.getProfileImageUrl(), userResponse.profileImageUrl());
+    }
+
+    @Test
+    @DisplayName("새로운 닉네임과 프로필이미지가 주어지면 유저의 정보가 업데이트된다.")
+    void edit_userFound_nicknameChangedAndProfileImageUploaded() {
+        String newNickname = "newNickname";
+        String newProfileImageUrl = "newProfileImageUrl";
+        MockMultipartFile newProfileImageFile = new MockMultipartFile(
+                "newProfileImageFile", "test.jpg", "image/jpeg", "test image".getBytes());
+        User existingUser = UserFixture.create(1L, "oldNickname", "1234");
+
+        when(userRepository.findById(existingUser.getId())).thenReturn(Optional.of(existingUser));
+        when(fileStore.uploadImage(newProfileImageFile)).thenReturn(newProfileImageUrl);
+
+        UserResponse updatedUser = userWriteService.edit(existingUser.getId(), newNickname, newProfileImageFile);
+
+        assertEquals(newNickname, updatedUser.nickname());
+        assertEquals(newProfileImageUrl, updatedUser.profileImageUrl());
+    }
+
+    @Test
+    @DisplayName("새로운 닉네임만 주어지고 프로필이미지가 주어지지 않으면 닉네임만 업데이트된다.")
+    void edit_nickname_notProfileImage() {
+        String newNickname = "newNickname";
+        User existingUser = UserFixture.create(1L, "oldNickname", "1234");
+
+        when(userRepository.findById(existingUser.getId())).thenReturn(Optional.of(existingUser));
+
+        UserResponse updatedUser = userWriteService.edit(existingUser.getId(), newNickname, null);
+
+        assertEquals(newNickname, updatedUser.nickname());
+        assertEquals(existingUser.getProfileImageUrl(), updatedUser.profileImageUrl());
     }
 }

--- a/src/test/java/com/numble/instagram/presentation/user/UserControllerDocTest.java
+++ b/src/test/java/com/numble/instagram/presentation/user/UserControllerDocTest.java
@@ -90,4 +90,37 @@ class UserControllerDocTest {
                         )
                 ));
     }
+
+    @Test
+    @DisplayName("프로필 수정은 완료되어야한다.")
+    void edit() throws Exception {
+        MockMultipartFile profileImageFile = new MockMultipartFile("profileImageFile", "image".getBytes());
+
+        UserResponse expectedUserResponse = new UserResponse(
+                1L, "new_test_user", "https://new_test_image_url", LocalDateTime.now().minusDays(1));
+        given(userWriteService.edit(1L, "new_test_user", profileImageFile))
+                .willReturn(expectedUserResponse);
+
+        mockMvc.perform(multipart("/api/user/edit")
+                        .file(profileImageFile)
+                        .param("nickname", "new_test_user")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document(DOCUMENT_IDENTIFIER,
+                        requestParts(
+                                partWithName("profileImageFile").description("파일 업로드")
+                        ),
+//                        formParameters(
+//                                parameterWithName("email").description("이메일"),
+//                                parameterWithName("password").description("비밀번호")
+//                        ),
+                        responseFields(
+                                fieldWithPath("id").description("유저 id"),
+                                fieldWithPath("nickname").description("유저 nickname"),
+                                fieldWithPath("profileImageUrl").description("유저 프로필 이미지 Url"),
+                                fieldWithPath("joinedAt").description("유저 가입일")
+                        )
+                ));
+    }
 }

--- a/src/test/java/com/numble/instagram/util/fixture/user/UserFixture.java
+++ b/src/test/java/com/numble/instagram/util/fixture/user/UserFixture.java
@@ -49,4 +49,8 @@ public class UserFixture {
 
         return new EasyRandom(param).nextObject(User.class);
     }
+
+    public static User create(String nickname) {
+        return new User(nickname, "1234", "https://");
+    }
 }


### PR DESCRIPTION
## 작업 주제

- 유저의 프로필 수정과, 프로필 조회 기능을 구현합니다.

## optional 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 프로필 수정 기능은 단순히 REST API관점에서 PUT 이나 PATCH를 이용하는게 맞다고 생각 했습니다. 하지만 multipartfile과 함께 데이터의 요청이 들어오기 때문에 mockMvc 테스트케이스를 짜다보니 POST가 강제되었습니다. 한 블로그의 글을 보고 multipartfile의 요청이 POST에 더 적합하다는 느낌을 받았습니다. 
- controller 테스트에서 그전에는 리졸버와 인터셉터를 mock으로 했었는데 테스트시 부작용이 많이 발생했습니다. 따라서 tokenprovider를 mock으로 설정하고 처리하자 테스트하기 수월해 졌습니다. 
- 프로필 조회 기능은 GetUserProfileUsecase를 이용해서 팔로워 수와 팔로잉 수를 조회해왔습니다.

## optional 관련 Docs

- [multipart요청이 POST에 적합한가에 대한 고찰의 블로그 포스트](https://mangkyu.tistory.com/218)

## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [x] base, compare branch가 적절하게 선택되었나요?
- [x] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)