### PR TITLE
사용자의 팔로우 목록, 팔로잉 목록 조회하기 기능 구현

### DIFF
--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -55,6 +55,38 @@ include::{snippets}/user/get-user-profile/http-request.adoc[]
 include::{snippets}/user/get-user-profile/path-parameters.adoc[]
 
 ==== Response
-include::{snippets}/user/get-user-profile/http-request.adoc[]
+include::{snippets}/user/get-user-profile/http-response.adoc[]
 - body
 include::{snippets}/user/get-user-profile/response-fields.adoc[]
+
+'''
+
+=== 팔로워 목록 조회
+
+==== Request
+include::{snippets}/user/get-followers/http-request.adoc[]
+
+- path parameter
+
+include::{snippets}/user/get-followers/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/user/get-followers/http-response.adoc[]
+- body
+include::{snippets}/user/get-followers/response-fields.adoc[]
+
+'''
+
+=== 팔로잉 목록 조회
+
+==== Request
+include::{snippets}/user/get-followings/http-request.adoc[]
+
+- path parameter
+
+include::{snippets}/user/get-followings/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/user/get-followings/http-response.adoc[]
+- body
+include::{snippets}/user/get-followings/response-fields.adoc[]

--- a/src/main/java/com/numble/instagram/application/auth/AuthService.java
+++ b/src/main/java/com/numble/instagram/application/auth/AuthService.java
@@ -5,9 +5,8 @@ import com.numble.instagram.application.auth.token.RefreshTokenProvider;
 import com.numble.instagram.application.auth.token.RefreshTokenRepository;
 import com.numble.instagram.application.auth.token.TokenProvider;
 import com.numble.instagram.domain.user.entity.User;
-import com.numble.instagram.domain.user.repository.UserRepository;
+import com.numble.instagram.domain.user.service.UserReadService;
 import com.numble.instagram.dto.common.LoginDto;
-import com.numble.instagram.exception.notfound.UserNotFoundException;
 import com.numble.instagram.exception.unauthorized.PasswordMismatchException;
 import com.numble.instagram.exception.unauthorized.RefreshTokenExpiredException;
 import com.numble.instagram.exception.unauthorized.RefreshTokenNotExistsException;
@@ -23,13 +22,12 @@ public class AuthService {
     private final TokenProvider tokenProvider;
     private final RefreshTokenProvider refreshTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
-    private final UserRepository userRepository;
+    private final UserReadService userReadService;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public LoginDto login(String nickname, String password) {
-        User loginUser = userRepository.findByNickname(nickname)
-                .orElseThrow(UserNotFoundException::new);
+        User loginUser = userReadService.getUserByNickname(nickname);
         if (!passwordEncoder.matches(password, loginUser.getPassword())) {
             throw new PasswordMismatchException();
         }

--- a/src/main/java/com/numble/instagram/application/usecase/follow/CreateFollowUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/follow/CreateFollowUsecase.java
@@ -6,9 +6,9 @@ import com.numble.instagram.domain.user.service.UserReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-@Service
 @RequiredArgsConstructor
-public class DestroyFollowUserUsecase {
+@Service
+public class CreateFollowUsecase {
 
     private final UserReadService userReadService;
     private final FollowWriteService followWriteService;
@@ -16,6 +16,6 @@ public class DestroyFollowUserUsecase {
     public Long execute(Long fromUserId, Long toUserId) {
         User fromUser = userReadService.getUser(fromUserId);
         User toUser = userReadService.getUser(toUserId);
-        return followWriteService.unfollow(fromUser, toUser);
+        return followWriteService.follow(fromUser, toUser).getToUser().getId();
     }
 }

--- a/src/main/java/com/numble/instagram/application/usecase/follow/CreateFollowUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/follow/CreateFollowUsecase.java
@@ -16,6 +16,6 @@ public class CreateFollowUsecase {
     public Long execute(Long fromUserId, Long toUserId) {
         User fromUser = userReadService.getUser(fromUserId);
         User toUser = userReadService.getUser(toUserId);
-        return followWriteService.follow(fromUser, toUser).getToUser().getId();
+        return followWriteService.follow(fromUser, toUser);
     }
 }

--- a/src/main/java/com/numble/instagram/application/usecase/follow/CreateFollowUserUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/follow/CreateFollowUserUsecase.java
@@ -1,4 +1,4 @@
-package com.numble.instagram.application.usecase;
+package com.numble.instagram.application.usecase.follow;
 
 import com.numble.instagram.domain.follow.service.FollowWriteService;
 import com.numble.instagram.domain.user.entity.User;

--- a/src/main/java/com/numble/instagram/application/usecase/follow/DestroyFollowUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/follow/DestroyFollowUsecase.java
@@ -6,9 +6,9 @@ import com.numble.instagram.domain.user.service.UserReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-@RequiredArgsConstructor
 @Service
-public class CreateFollowUserUsecase {
+@RequiredArgsConstructor
+public class DestroyFollowUsecase {
 
     private final UserReadService userReadService;
     private final FollowWriteService followWriteService;
@@ -16,6 +16,6 @@ public class CreateFollowUserUsecase {
     public Long execute(Long fromUserId, Long toUserId) {
         User fromUser = userReadService.getUser(fromUserId);
         User toUser = userReadService.getUser(toUserId);
-        return followWriteService.follow(fromUser, toUser).getToUser().getId();
+        return followWriteService.unfollow(fromUser, toUser);
     }
 }

--- a/src/main/java/com/numble/instagram/application/usecase/follow/DestroyFollowUserUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/follow/DestroyFollowUserUsecase.java
@@ -1,4 +1,4 @@
-package com.numble.instagram.application.usecase;
+package com.numble.instagram.application.usecase.follow;
 
 import com.numble.instagram.domain.follow.service.FollowWriteService;
 import com.numble.instagram.domain.user.entity.User;

--- a/src/main/java/com/numble/instagram/application/usecase/user/GetFollowersUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/user/GetFollowersUsecase.java
@@ -20,7 +20,7 @@ public class GetFollowersUsecase {
 
     public List<UserResponse> execute(Long userId) {
         User user = userReadService.getUser(userId);
-        return followReadService.getFollowers(user).stream()
+        return followReadService.getFollowersFollow(user).stream()
                 .map(Follow::getToUser)
                 .map(UserResponse::from)
                 .sorted(Comparator.comparing(UserResponse::nickname))

--- a/src/main/java/com/numble/instagram/application/usecase/user/GetFollowersUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/user/GetFollowersUsecase.java
@@ -1,0 +1,29 @@
+package com.numble.instagram.application.usecase.user;
+
+import com.numble.instagram.domain.follow.entity.Follow;
+import com.numble.instagram.domain.follow.service.FollowReadService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.response.user.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetFollowersUsecase {
+
+    private final UserReadService userReadService;
+    private final FollowReadService followReadService;
+
+    public List<UserResponse> execute(Long userId) {
+        User user = userReadService.getUser(userId);
+        return followReadService.getFollowers(user).stream()
+                .map(Follow::getToUser)
+                .map(UserResponse::from)
+                .sorted(Comparator.comparing(UserResponse::nickname))
+                .toList();
+    }
+}

--- a/src/main/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecase.java
@@ -1,0 +1,29 @@
+package com.numble.instagram.application.usecase.user;
+
+import com.numble.instagram.domain.follow.entity.Follow;
+import com.numble.instagram.domain.follow.service.FollowReadService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.response.user.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class GetFollowingsUsecase {
+
+    private final UserReadService userReadService;
+    private final FollowReadService followReadService;
+
+    public List<UserResponse> execute(Long userId) {
+        User user = userReadService.getUser(userId);
+        return followReadService.getFollowingsFollow(user).stream()
+                .map(Follow::getToUser)
+                .map(UserResponse::from)
+                .sorted(Comparator.comparing(UserResponse::nickname))
+                .toList();
+    }
+}

--- a/src/main/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecase.java
@@ -21,7 +21,7 @@ public class GetFollowingsUsecase {
     public List<UserResponse> execute(Long userId) {
         User user = userReadService.getUser(userId);
         return followReadService.getFollowingsFollow(user).stream()
-                .map(Follow::getToUser)
+                .map(Follow::getFromUser)
                 .map(UserResponse::from)
                 .sorted(Comparator.comparing(UserResponse::nickname))
                 .toList();

--- a/src/main/java/com/numble/instagram/application/usecase/user/GetUserProfileUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/user/GetUserProfileUsecase.java
@@ -1,4 +1,4 @@
-package com.numble.instagram.application.usecase;
+package com.numble.instagram.application.usecase.user;
 
 import com.numble.instagram.domain.follow.service.FollowReadService;
 import com.numble.instagram.domain.user.entity.User;

--- a/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
@@ -11,4 +11,5 @@ public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRep
 
     Optional<Follow> findByFromUserAndToUser(User fromUser, User toUser);
     List<Follow> findByToUser(User toUser);
+    List<Follow> findByFromUser(User fromUser);
 }

--- a/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
@@ -4,9 +4,11 @@ import com.numble.instagram.domain.follow.entity.Follow;
 import com.numble.instagram.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRepositoryCustom {
 
     Optional<Follow> findByFromUserAndToUser(User fromUser, User toUser);
+    List<Follow> findByToUser(User toUser);
 }

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
@@ -27,4 +27,8 @@ public class FollowReadService {
     public List<Follow> getFollowersFollow(User toUser) {
         return followRepository.findByToUser(toUser);
     }
+
+    public List<Follow> getFollowingsFollow(User fromUser) {
+        return followRepository.findByFromUser(fromUser);
+    }
 }

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
@@ -1,9 +1,13 @@
 package com.numble.instagram.domain.follow.service;
 
+import com.numble.instagram.domain.follow.entity.Follow;
 import com.numble.instagram.domain.follow.repository.FollowRepository;
+import com.numble.instagram.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,5 +22,9 @@ public class FollowReadService {
 
     public Long getFollowingCount(Long userId) {
         return followRepository.getFollowingCount(userId);
+    }
+
+    public List<Follow> getFollowers(User toUser) {
+        return followRepository.findByToUser(toUser);
     }
 }

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
@@ -24,7 +24,7 @@ public class FollowReadService {
         return followRepository.getFollowingCount(userId);
     }
 
-    public List<Follow> getFollowers(User toUser) {
+    public List<Follow> getFollowersFollow(User toUser) {
         return followRepository.findByToUser(toUser);
     }
 }

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
@@ -18,10 +18,10 @@ public class FollowWriteService {
 
     private final FollowRepository followRepository;
 
-    public Follow follow(User fromUser, User toUser) {
+    public Long follow(User fromUser, User toUser) {
         checkFollowed(fromUser, toUser);
         Follow follow = Follow.create(fromUser, toUser);
-        return followRepository.save(follow);
+        return followRepository.save(follow).getToUser().getId();
     }
 
     public Long unfollow(User fromUser, User toUser) {

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
@@ -34,7 +34,6 @@ public class FollowWriteService {
 
     private void checkFollowed(User fromUser, User toUser) {
         Optional<Follow> optionalFollow = followRepository.findByFromUserAndToUser(fromUser, toUser);
-        followRepository.findByFromUserAndToUser(fromUser, toUser);
         if (optionalFollow.isPresent()) {
             throw new AlreadyFollowedUserException();
         }

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowWriteService.java
@@ -20,16 +20,16 @@ public class FollowWriteService {
 
     public Long follow(User fromUser, User toUser) {
         checkFollowed(fromUser, toUser);
-        Follow follow = Follow.create(fromUser, toUser);
-        return followRepository.save(follow).getToUser().getId();
+        Follow newFollow = Follow.create(fromUser, toUser);
+        return followRepository.save(newFollow).getToUser().getId();
     }
 
     public Long unfollow(User fromUser, User toUser) {
         Follow followedFollow = followRepository.findByFromUserAndToUser(fromUser, toUser)
                 .orElseThrow(NotFollowedUserException::new);
-        Long toUserId = toUser.getId();
+        Long deletedToUserId = toUser.getId();
         followRepository.delete(followedFollow);
-        return toUserId;
+        return deletedToUserId;
     }
 
     private void checkFollowed(User fromUser, User toUser) {

--- a/src/main/java/com/numble/instagram/domain/user/service/UserReadService.java
+++ b/src/main/java/com/numble/instagram/domain/user/service/UserReadService.java
@@ -18,4 +18,9 @@ public class UserReadService {
         return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
     }
+
+    public User getUserByNickname(String nickname) {
+        return userRepository.findByNickname(nickname)
+                .orElseThrow(UserNotFoundException::new);
+    }
 }

--- a/src/main/java/com/numble/instagram/presentation/follow/FollowController.java
+++ b/src/main/java/com/numble/instagram/presentation/follow/FollowController.java
@@ -1,7 +1,7 @@
 package com.numble.instagram.presentation.follow;
 
-import com.numble.instagram.application.usecase.follow.CreateFollowUserUsecase;
-import com.numble.instagram.application.usecase.follow.DestroyFollowUserUsecase;
+import com.numble.instagram.application.usecase.follow.CreateFollowUsecase;
+import com.numble.instagram.application.usecase.follow.DestroyFollowUsecase;
 import com.numble.instagram.dto.common.FollowDto;
 import com.numble.instagram.presentation.auth.AuthenticatedUser;
 import com.numble.instagram.presentation.auth.Login;
@@ -16,14 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/follow")
 public class FollowController {
 
-    private final CreateFollowUserUsecase createFollowUserUsecase;
-    private final DestroyFollowUserUsecase destroyFollowUserUsecase;
+    private final CreateFollowUsecase createFollowUsecase;
+    private final DestroyFollowUsecase destroyFollowUsecase;
 
     @Login
     @PostMapping("/{toUserId}")
     public FollowDto follow(@AuthenticatedUser Long fromUserId,
                             @PathVariable Long toUserId) {
-        Long savedToUserId = createFollowUserUsecase.execute(fromUserId, toUserId);
+        Long savedToUserId = createFollowUsecase.execute(fromUserId, toUserId);
         return FollowDto.from(savedToUserId);
     }
 
@@ -31,7 +31,7 @@ public class FollowController {
     @PostMapping("/unfollow/{toUserId}")
     public FollowDto unfollow(@AuthenticatedUser Long fromUserId,
                             @PathVariable Long toUserId) {
-        Long deletedToUserId = destroyFollowUserUsecase.execute(fromUserId, toUserId);
+        Long deletedToUserId = destroyFollowUsecase.execute(fromUserId, toUserId);
         return FollowDto.from(deletedToUserId);
     }
 }

--- a/src/main/java/com/numble/instagram/presentation/follow/FollowController.java
+++ b/src/main/java/com/numble/instagram/presentation/follow/FollowController.java
@@ -1,7 +1,7 @@
 package com.numble.instagram.presentation.follow;
 
-import com.numble.instagram.application.usecase.CreateFollowUserUsecase;
-import com.numble.instagram.application.usecase.DestroyFollowUserUsecase;
+import com.numble.instagram.application.usecase.follow.CreateFollowUserUsecase;
+import com.numble.instagram.application.usecase.follow.DestroyFollowUserUsecase;
 import com.numble.instagram.dto.common.FollowDto;
 import com.numble.instagram.presentation.auth.AuthenticatedUser;
 import com.numble.instagram.presentation.auth.Login;

--- a/src/main/java/com/numble/instagram/presentation/user/UserController.java
+++ b/src/main/java/com/numble/instagram/presentation/user/UserController.java
@@ -1,6 +1,7 @@
 package com.numble.instagram.presentation.user;
 
-import com.numble.instagram.application.usecase.GetUserProfileUsecase;
+import com.numble.instagram.application.usecase.user.GetFollowersUsecase;
+import com.numble.instagram.application.usecase.user.GetUserProfileUsecase;
 import com.numble.instagram.domain.user.service.UserWriteService;
 import com.numble.instagram.dto.request.user.UserEditRequest;
 import com.numble.instagram.dto.request.user.UserJoinRequest;
@@ -12,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
@@ -19,6 +22,7 @@ public class UserController {
 
     private final UserWriteService userWriteService;
     private final GetUserProfileUsecase getUserProfileUsecase;
+    private final GetFollowersUsecase getFollowersUsecase;
 
     @PostMapping
     public UserResponse join(@Validated UserJoinRequest userJoinRequest) {
@@ -35,5 +39,10 @@ public class UserController {
     @GetMapping("/{userId}")
     public UserDetailResponse get(@PathVariable Long userId) {
         return getUserProfileUsecase.execute(userId);
+    }
+
+    @GetMapping("{userId}/followers")
+    public List<UserResponse> getFollowers(@PathVariable Long userId) {
+        return getFollowersUsecase.execute(userId);
     }
 }

--- a/src/main/java/com/numble/instagram/presentation/user/UserController.java
+++ b/src/main/java/com/numble/instagram/presentation/user/UserController.java
@@ -1,6 +1,7 @@
 package com.numble.instagram.presentation.user;
 
 import com.numble.instagram.application.usecase.user.GetFollowersUsecase;
+import com.numble.instagram.application.usecase.user.GetFollowingsUsecase;
 import com.numble.instagram.application.usecase.user.GetUserProfileUsecase;
 import com.numble.instagram.domain.user.service.UserWriteService;
 import com.numble.instagram.dto.request.user.UserEditRequest;
@@ -23,6 +24,7 @@ public class UserController {
     private final UserWriteService userWriteService;
     private final GetUserProfileUsecase getUserProfileUsecase;
     private final GetFollowersUsecase getFollowersUsecase;
+    private final GetFollowingsUsecase getFollowingsUsecase;
 
     @PostMapping
     public UserResponse join(@Validated UserJoinRequest userJoinRequest) {
@@ -44,5 +46,10 @@ public class UserController {
     @GetMapping("{userId}/followers")
     public List<UserResponse> getFollowers(@PathVariable Long userId) {
         return getFollowersUsecase.execute(userId);
+    }
+
+    @GetMapping("{userId}/followings")
+    public List<UserResponse> getFollowings(@PathVariable Long userId) {
+        return getFollowingsUsecase.execute(userId);
     }
 }

--- a/src/test/java/com/numble/instagram/application/usecase/user/GetFollowersUsecaseTest.java
+++ b/src/test/java/com/numble/instagram/application/usecase/user/GetFollowersUsecaseTest.java
@@ -1,0 +1,50 @@
+package com.numble.instagram.application.usecase.user;
+
+import com.numble.instagram.domain.follow.entity.Follow;
+import com.numble.instagram.domain.follow.service.FollowReadService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.response.user.UserResponse;
+import com.numble.instagram.util.fixture.follow.FollowFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetFollowersUsecaseTest {
+
+    @Mock
+    private UserReadService userReadService;
+
+    @Mock
+    private FollowReadService followReadService;
+
+    @InjectMocks
+    private GetFollowersUsecase getFollowersUsecase;
+
+    @Test
+    @DisplayName("결과가 유저의 닉네임 순으로 sort 되었는지 확인한다.")
+    void testExecute() {
+        User user = UserFixture.create("user1");
+        User follower1 = UserFixture.create("follower1");
+        User follower2 = UserFixture.create("follower2");
+        Follow follow1 = FollowFixture.create(user, follower1);
+        Follow follow2 = FollowFixture.create(user, follower2);
+        List<Follow> followList = List.of(follow1, follow2);
+        when(userReadService.getUser(user.getId())).thenReturn(user);
+        when(followReadService.getFollowersFollow(user)).thenReturn(followList);
+
+        List<UserResponse> result = getFollowersUsecase.execute(user.getId());
+
+        assertEquals("follower1", result.get(0).nickname());
+    }
+}

--- a/src/test/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecaseTest.java
+++ b/src/test/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecaseTest.java
@@ -1,0 +1,50 @@
+package com.numble.instagram.application.usecase.user;
+
+import com.numble.instagram.domain.follow.entity.Follow;
+import com.numble.instagram.domain.follow.service.FollowReadService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.response.user.UserResponse;
+import com.numble.instagram.util.fixture.follow.FollowFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetFollowingsUsecaseTest {
+
+    @Mock
+    private UserReadService userReadService;
+
+    @Mock
+    private FollowReadService followReadService;
+
+    @InjectMocks
+    private GetFollowingsUsecase getFollowingsUsecase;
+
+    @Test
+    @DisplayName("결과가 유저의 닉네임 순으로 sort 되었는지 확인한다.")
+    void testExecute() {
+        User user = UserFixture.create("user1");
+        User following1 = UserFixture.create("following1");
+        User following2 = UserFixture.create("following2");
+        Follow followingFollow1 = FollowFixture.create(following1, user);
+        Follow followingFollow2 = FollowFixture.create(following2, user);
+        List<Follow> followList = List.of(followingFollow1, followingFollow2);
+        when(userReadService.getUser(user.getId())).thenReturn(user);
+        when(followReadService.getFollowingsFollow(user)).thenReturn(followList);
+
+        List<UserResponse> result = getFollowingsUsecase.execute(user.getId());
+
+        assertEquals("following1", result.get(0).nickname());
+    }
+}

--- a/src/test/java/com/numble/instagram/domain/follow/service/FollowReadServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/follow/service/FollowReadServiceTest.java
@@ -55,13 +55,51 @@ class FollowReadServiceTest {
         List<Follow> followers = new LinkedList<>();
         LongStream.range(1, 20).forEach(i -> {
             User followerUser = UserFixture.create("followerUser");
-            userRepository.save(followerUser);
+            userRepository.saveAndFlush(followerUser);
             followers.add(FollowFixture.create(followerUser, user));
         });
-        followRepository.saveAll(followers);
+        followRepository.saveAllAndFlush(followers);
 
         Long followingCount = followReadService.getFollowerCount(user.getId());
 
         assertEquals(19L, followingCount);
     }
+
+    @Test
+    @DisplayName("팔로워 팔로우들을 가져온다.")
+    void getFollowersFollow() {
+        User user = UserFixture.create("user");
+        userRepository.save(user);
+
+        List<Follow> followers = new LinkedList<>();
+        LongStream.range(1, 20).forEach(i -> {
+            User followerUser = UserFixture.create("followerUser");
+            userRepository.saveAndFlush(followerUser);
+            followers.add(FollowFixture.create(followerUser, user));
+        });
+        followRepository.saveAllAndFlush(followers);
+
+        List<Follow> followersFollow = followReadService.getFollowersFollow(user);
+
+        assertEquals(19, followersFollow.size());
+    }
+
+//    @Test
+//    @DisplayName("팔로잉 팔로우들을 가져온다")
+//    void getFollowingsFollow() {
+//        User user = UserFixture.create("user");
+//        userRepository.save(user);
+//
+//        List<Follow> followings = new LinkedList<>();
+//        LongStream.range(1, 20).forEach(i -> {
+//            User FollowingUser = UserFixture.create("followingUser");
+//            userRepository.saveAndFlush(FollowingUser);
+//            followings.add(FollowFixture.create(user, FollowingUser));
+//        });
+//        followRepository.saveAllAndFlush(followings);
+//
+//        List<Follow> followingsFollow = followReadService.getFollowingsFollow(user.getId());
+//
+//        assertEquals(19, followingsFollow.size());
+//    }
 }

--- a/src/test/java/com/numble/instagram/domain/follow/service/FollowReadServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/follow/service/FollowReadServiceTest.java
@@ -84,22 +84,22 @@ class FollowReadServiceTest {
         assertEquals(19, followersFollow.size());
     }
 
-//    @Test
-//    @DisplayName("팔로잉 팔로우들을 가져온다")
-//    void getFollowingsFollow() {
-//        User user = UserFixture.create("user");
-//        userRepository.save(user);
-//
-//        List<Follow> followings = new LinkedList<>();
-//        LongStream.range(1, 20).forEach(i -> {
-//            User FollowingUser = UserFixture.create("followingUser");
-//            userRepository.saveAndFlush(FollowingUser);
-//            followings.add(FollowFixture.create(user, FollowingUser));
-//        });
-//        followRepository.saveAllAndFlush(followings);
-//
-//        List<Follow> followingsFollow = followReadService.getFollowingsFollow(user.getId());
-//
-//        assertEquals(19, followingsFollow.size());
-//    }
+    @Test
+    @DisplayName("팔로잉 팔로우들을 가져온다")
+    void getFollowingsFollow() {
+        User user = UserFixture.create("user");
+        userRepository.save(user);
+
+        List<Follow> followings = new LinkedList<>();
+        LongStream.range(1, 20).forEach(i -> {
+            User FollowingUser = UserFixture.create("followingUser");
+            userRepository.saveAndFlush(FollowingUser);
+            followings.add(FollowFixture.create(user, FollowingUser));
+        });
+        followRepository.saveAllAndFlush(followings);
+
+        List<Follow> followingsFollow = followReadService.getFollowingsFollow(user);
+
+        assertEquals(19, followingsFollow.size());
+    }
 }

--- a/src/test/java/com/numble/instagram/domain/follow/service/FollowWriteServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/follow/service/FollowWriteServiceTest.java
@@ -31,7 +31,7 @@ class FollowWriteServiceTest {
     private FollowRepository followRepository;
 
     @Test
-    @DisplayName("팔로우는 완료 되어야 한다. ")
+    @DisplayName("팔로우는 완료 되어야 한다.")
     void followTest() {
         User fromUser = UserFixture.create(1L, "user1");
         User toUser = UserFixture.create(2L, "user2");
@@ -39,9 +39,9 @@ class FollowWriteServiceTest {
 
         when(followRepository.save(any(Follow.class))).thenReturn(follow);
 
-        Follow savedFollow = followWriteService.follow(fromUser, toUser);
+        Long savedToUserId = followWriteService.follow(fromUser, toUser);
 
-        assertEquals(follow, savedFollow);
+        assertEquals(toUser.getId(), savedToUserId);
     }
 
     @Test

--- a/src/test/java/com/numble/instagram/presentation/follow/FollowControllerDocTest.java
+++ b/src/test/java/com/numble/instagram/presentation/follow/FollowControllerDocTest.java
@@ -1,8 +1,8 @@
 package com.numble.instagram.presentation.follow;
 
 import com.numble.instagram.application.auth.token.TokenProvider;
-import com.numble.instagram.application.usecase.CreateFollowUserUsecase;
-import com.numble.instagram.application.usecase.DestroyFollowUserUsecase;
+import com.numble.instagram.application.usecase.follow.CreateFollowUserUsecase;
+import com.numble.instagram.application.usecase.follow.DestroyFollowUserUsecase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/numble/instagram/presentation/follow/FollowControllerDocTest.java
+++ b/src/test/java/com/numble/instagram/presentation/follow/FollowControllerDocTest.java
@@ -1,8 +1,8 @@
 package com.numble.instagram.presentation.follow;
 
 import com.numble.instagram.application.auth.token.TokenProvider;
-import com.numble.instagram.application.usecase.follow.CreateFollowUserUsecase;
-import com.numble.instagram.application.usecase.follow.DestroyFollowUserUsecase;
+import com.numble.instagram.application.usecase.follow.CreateFollowUsecase;
+import com.numble.instagram.application.usecase.follow.DestroyFollowUsecase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,9 +39,9 @@ class FollowControllerDocTest {
 
     private MockMvc mockMvc;
     @MockBean
-    private CreateFollowUserUsecase createFollowUserUsecase;
+    private CreateFollowUsecase createFollowUsecase;
     @MockBean
-    private DestroyFollowUserUsecase destroyFollowUserUsecase;
+    private DestroyFollowUsecase destroyFollowUsecase;
     @MockBean
     private TokenProvider tokenProvider;
     @Autowired
@@ -67,7 +67,7 @@ class FollowControllerDocTest {
         String authorizationHeader = "Bearer access-token";
         given(tokenProvider.isValidToken(authorizationHeader)).willReturn(true);
         given(tokenProvider.getUserId(authorizationHeader)).willReturn(fromUserId);
-        given(destroyFollowUserUsecase.execute(eq(fromUserId), eq(toUserId))).willReturn(toUserId);
+        given(destroyFollowUsecase.execute(eq(fromUserId), eq(toUserId))).willReturn(toUserId);
 
         mockMvc.perform(post("/api/follow/unfollow/{toUserId}", toUserId)
                         .header(HttpHeaders.AUTHORIZATION, authorizationHeader))
@@ -92,7 +92,7 @@ class FollowControllerDocTest {
         String authorizationHeader = "Bearer access-token";
         given(tokenProvider.isValidToken(authorizationHeader)).willReturn(true);
         given(tokenProvider.getUserId(authorizationHeader)).willReturn(fromUserId);
-        given(createFollowUserUsecase.execute(eq(fromUserId), eq(toUserId))).willReturn(toUserId);
+        given(createFollowUsecase.execute(eq(fromUserId), eq(toUserId))).willReturn(toUserId);
 
         mockMvc.perform(post("/api/follow/{toUserId}", toUserId)
                         .header(HttpHeaders.AUTHORIZATION, authorizationHeader))

--- a/src/test/java/com/numble/instagram/presentation/user/UserControllerDocTest.java
+++ b/src/test/java/com/numble/instagram/presentation/user/UserControllerDocTest.java
@@ -1,7 +1,7 @@
 package com.numble.instagram.presentation.user;
 
 import com.numble.instagram.application.auth.token.TokenProvider;
-import com.numble.instagram.application.usecase.GetUserProfileUsecase;
+import com.numble.instagram.application.usecase.user.GetUserProfileUsecase;
 import com.numble.instagram.domain.user.service.UserWriteService;
 import com.numble.instagram.dto.request.user.UserEditRequest;
 import com.numble.instagram.dto.request.user.UserJoinRequest;

--- a/src/test/java/com/numble/instagram/util/fixture/user/UserResponseFixture.java
+++ b/src/test/java/com/numble/instagram/util/fixture/user/UserResponseFixture.java
@@ -1,0 +1,14 @@
+package com.numble.instagram.util.fixture.user;
+
+import com.numble.instagram.dto.response.user.UserResponse;
+
+import java.time.LocalDateTime;
+
+public class UserResponseFixture {
+
+    private static Long id = 0L;
+
+    public static UserResponse create(String nickname) {
+        return new UserResponse(id++, nickname, "https://profile.com", LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
## 작업 주제

- 사용자의 팔로우 목록, 팔로잉 목록 조회하기 기능을 구현하였습니다.

## optional 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 사용자 팔로우 목록과 팔로잉 목록은 비슷한 기능입니다. 
- 사용자를 조회 -> follow repository에서 toUser나 fromUser 를 조회 -> Follow에서 User를 가져와 -> 닉네임 순서로 정렬하는 방법으로 구현했습니다. 
- 같은 풀 리퀘스트에 있으면 안되지만 변수명,메서드명, 계층에 따른 고민으로 리팩토링을 진행했습니다.

## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [x] base, compare branch가 적절하게 선택되었나요?
- [x] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)