### PR TITLE
글 생성, 글 수정 기능 구현하기

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -11,3 +11,5 @@ include::auth.adoc[]
 include::user.adoc[]
 
 include::follow.adoc[]
+
+include::post.adoc[]

--- a/src/docs/asciidoc/post.adoc
+++ b/src/docs/asciidoc/post.adoc
@@ -1,0 +1,21 @@
+== *Post*
+
+'''
+
+=== 글 생성
+==== Request
+include::{snippets}/post/register/http-request.adoc[]
+- param
+
+현재 rest-docs 3.0 버전에서 requestParameters를 지원하지 않고 formParameters, queryParameters로 나뉘면서
+multipart 요청시 form-data가 정상적으로 작동하지 않는 현상 때문에 multipart 요청시 parameter를 docs로 만들지 못하고 있습니다.
+
+글 생성 시 필요한 form-data는 content(String) 글 내용 입니다. 감사합니다.
+
+- part
+include::{snippets}/post/register/request-parts.adoc[]
+
+==== Response
+include::{snippets}/post/register/http-response.adoc[]
+- body
+include::{snippets}/post/register/response-fields.adoc[]

--- a/src/docs/asciidoc/post.adoc
+++ b/src/docs/asciidoc/post.adoc
@@ -19,3 +19,28 @@ include::{snippets}/post/register/request-parts.adoc[]
 include::{snippets}/post/register/http-response.adoc[]
 - body
 include::{snippets}/post/register/response-fields.adoc[]
+
+'''
+
+=== 글 수정
+==== Request
+include::{snippets}/post/edit/http-request.adoc[]
+
+- path parameter
+
+include::{snippets}/post/edit/path-parameters.adoc[]
+
+- param
+
+현재 rest-docs 3.0 버전에서 requestParameters를 지원하지 않고 formParameters, queryParameters로 나뉘면서
+multipart 요청시 form-data가 정상적으로 작동하지 않는 현상 때문에 multipart 요청시 parameter를 docs로 만들지 못하고 있습니다.
+
+글 수정 시 필요한 form-data는 content(String) 글 내용 입니다. 감사합니다.
+
+- part
+include::{snippets}/post/edit/request-parts.adoc[]
+
+==== Response
+include::{snippets}/post/edit/http-response.adoc[]
+- body
+include::{snippets}/post/edit/response-fields.adoc[]

--- a/src/main/java/com/numble/instagram/application/usecase/post/CreatePostUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/post/CreatePostUsecase.java
@@ -1,0 +1,41 @@
+package com.numble.instagram.application.usecase.post;
+
+import com.numble.instagram.domain.follow.entity.Follow;
+import com.numble.instagram.domain.follow.service.FollowReadService;
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.post.service.FeedWriteService;
+import com.numble.instagram.domain.post.service.PostWriteService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.request.post.PostCreateRequest;
+import com.numble.instagram.dto.response.post.PostResponse;
+import com.numble.instagram.support.file.FileStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CreatePostUsecase {
+
+    private final UserReadService userReadService;
+    private final PostWriteService postWriteService;
+    private final FollowReadService followReadService;
+    private final FeedWriteService feedWriteService;
+    private final FileStore fileStore;
+
+    public PostResponse execute(Long userId, PostCreateRequest postCreateRequest) {
+        User writerUser = userReadService.getUser(userId);
+        String postImageUrl = fileStore.uploadImage(postCreateRequest.postImageFile());
+
+        Post newPost = postWriteService.register(writerUser, postCreateRequest.content(), postImageUrl);
+        List<User> followers = followReadService.getFollowersFollow(writerUser).stream()
+                .map(Follow::getFromUser)
+                .toList();
+
+        feedWriteService.deliveryToFeed(newPost, followers);
+
+        return PostResponse.from(newPost);
+    }
+}

--- a/src/main/java/com/numble/instagram/application/usecase/post/EditPostUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/post/EditPostUsecase.java
@@ -1,0 +1,34 @@
+package com.numble.instagram.application.usecase.post;
+
+import com.numble.instagram.domain.post.dto.PostDto;
+import com.numble.instagram.domain.post.service.PostWriteService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.request.post.PostEditRequest;
+import com.numble.instagram.dto.response.post.PostResponse;
+import com.numble.instagram.support.file.FileStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EditPostUsecase {
+
+    private final UserReadService userReadService;
+    private final PostWriteService postWriteService;
+    private final FileStore fileStore;
+
+    public PostResponse execute(Long userId, Long postId, PostEditRequest postEditRequest) {
+        User user = userReadService.getUser(userId);
+
+        if (postEditRequest.postImageFile() == null || postEditRequest.postImageFile().isEmpty()) {
+            PostDto editedPost = postWriteService.edit(user, postId, postEditRequest.content(), null);
+            return PostResponse.from(editedPost.post());
+        }
+
+        String uploadedImage = fileStore.uploadImage(postEditRequest.postImageFile());
+        PostDto editedPost = postWriteService.edit(user, postId, postEditRequest.content(), uploadedImage);
+        fileStore.deleteFile(editedPost.willDeleteImageUrl());
+        return PostResponse.from(editedPost.post());
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/post/dto/PostDto.java
+++ b/src/main/java/com/numble/instagram/domain/post/dto/PostDto.java
@@ -1,0 +1,18 @@
+package com.numble.instagram.domain.post.dto;
+
+import com.numble.instagram.domain.post.entity.Post;
+
+public record PostDto(Post post, String willDeleteImageUrl) {
+
+    public PostDto(Post post) {
+        this(post, null);
+    }
+
+    public static PostDto from(Post post, String willDeleteImageUrl) {
+        return new PostDto(post, willDeleteImageUrl);
+    }
+
+    public static PostDto from(Post post) {
+        return new PostDto(post);
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/post/entity/Feed.java
+++ b/src/main/java/com/numble/instagram/domain/post/entity/Feed.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -18,11 +19,11 @@ public class Feed {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/src/main/java/com/numble/instagram/domain/post/entity/Feed.java
+++ b/src/main/java/com/numble/instagram/domain/post/entity/Feed.java
@@ -1,0 +1,37 @@
+package com.numble.instagram.domain.post.entity;
+
+import com.numble.instagram.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Feed {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Feed(User user, Post post, LocalDateTime createdAt) {
+        this.user = user;
+        this.post = post;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/post/entity/Post.java
+++ b/src/main/java/com/numble/instagram/domain/post/entity/Post.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -25,7 +26,7 @@ public class Post {
 
     private String content;
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User writerUser;
 

--- a/src/main/java/com/numble/instagram/domain/post/entity/Post.java
+++ b/src/main/java/com/numble/instagram/domain/post/entity/Post.java
@@ -1,0 +1,53 @@
+package com.numble.instagram.domain.post.entity;
+
+import com.numble.instagram.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private String postImageUrl;
+
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User writerUser;
+
+    private Long likeCount;
+
+    @Column(updatable = false)
+    private LocalDate createdDate;
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    private void onPrePersist() {
+        this.likeCount = 0L;
+        this.createdDate = LocalDate.now();
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public Post(String postImageUrl, String content, User writerUser) {
+        this.postImageUrl = postImageUrl;
+        this.content = content;
+        this.writerUser = writerUser;
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/post/entity/Post.java
+++ b/src/main/java/com/numble/instagram/domain/post/entity/Post.java
@@ -51,4 +51,18 @@ public class Post {
         this.content = content;
         this.writerUser = writerUser;
     }
+
+    public boolean isWriter(User user) {
+        return writerUser == user;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public String updatePostImageUrl(String postImageUrl) {
+        String willDeleteImageUrl = this.postImageUrl;
+        this.postImageUrl = postImageUrl;
+        return willDeleteImageUrl;
+    }
 }

--- a/src/main/java/com/numble/instagram/domain/post/repository/FeedRepository.java
+++ b/src/main/java/com/numble/instagram/domain/post/repository/FeedRepository.java
@@ -1,0 +1,7 @@
+package com.numble.instagram.domain.post.repository;
+
+import com.numble.instagram.domain.post.entity.Feed;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+}

--- a/src/main/java/com/numble/instagram/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/numble/instagram/domain/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.numble.instagram.domain.post.repository;
+
+import com.numble.instagram.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/numble/instagram/domain/post/service/FeedWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/FeedWriteService.java
@@ -26,7 +26,7 @@ public class FeedWriteService {
         feedRepository.saveAll(feeds);
     }
 
-    public Feed toFeed(Post newPost, User follower) {
+    private Feed toFeed(Post newPost, User follower) {
         return Feed.builder()
                 .user(follower)
                 .post(newPost)

--- a/src/main/java/com/numble/instagram/domain/post/service/FeedWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/FeedWriteService.java
@@ -1,0 +1,36 @@
+package com.numble.instagram.domain.post.service;
+
+import com.numble.instagram.domain.post.entity.Feed;
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.post.repository.FeedRepository;
+import com.numble.instagram.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FeedWriteService {
+
+    private final FeedRepository feedRepository;
+
+    public void deliveryToFeed(Post newPost, List<User> followers) {
+        List<Feed> feeds = followers.stream()
+                .map(follower -> toFeed(newPost, follower))
+                .toList();
+
+        // TODO bulkInsert 하는 방법으로 고려해볼 것
+        feedRepository.saveAll(feeds);
+    }
+
+    public Feed toFeed(Post newPost, User follower) {
+        return Feed.builder()
+                .user(follower)
+                .post(newPost)
+                .createdAt(newPost.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/post/service/PostWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/PostWriteService.java
@@ -1,0 +1,25 @@
+package com.numble.instagram.domain.post.service;
+
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.post.repository.PostRepository;
+import com.numble.instagram.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostWriteService {
+
+    private final PostRepository postRepository;
+
+    public Post register(User writerUser, String content, String postImageUrl) {
+        Post newPost = Post.builder()
+                .writerUser(writerUser)
+                .content(content)
+                .postImageUrl(postImageUrl)
+                .build();
+        return postRepository.save(newPost);
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/post/service/PostWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/PostWriteService.java
@@ -1,8 +1,11 @@
 package com.numble.instagram.domain.post.service;
 
+import com.numble.instagram.domain.post.dto.PostDto;
 import com.numble.instagram.domain.post.entity.Post;
 import com.numble.instagram.domain.post.repository.PostRepository;
 import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.exception.badrequest.NotPostWriterException;
+import com.numble.instagram.exception.notfound.PostNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,5 +24,23 @@ public class PostWriteService {
                 .postImageUrl(postImageUrl)
                 .build();
         return postRepository.save(newPost);
+    }
+
+    public PostDto edit(User user, Long postId, String content, String postImageUrl) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(PostNotFoundException::new);
+        checkWriter(user, post);
+        post.updateContent(content);
+        if (postImageUrl != null) {
+            String willDeleteImageUrl = post.updatePostImageUrl(postImageUrl);
+            return PostDto.from(post, willDeleteImageUrl);
+        }
+        return PostDto.from(post);
+    }
+
+    private static void checkWriter(User user, Post post) {
+        if (!post.isWriter(user)) {
+            throw new NotPostWriterException();
+        }
     }
 }

--- a/src/main/java/com/numble/instagram/dto/request/post/PostCreateRequest.java
+++ b/src/main/java/com/numble/instagram/dto/request/post/PostCreateRequest.java
@@ -1,20 +1,8 @@
 package com.numble.instagram.dto.request.post;
 
-import com.numble.instagram.exception.badrequest.ImageFileNotExistsException;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
 
-public record PostCreateRequest(@NotBlank String content, MultipartFile postImageFile) {
-
-    public PostCreateRequest(String content, MultipartFile postImageFile) {
-        this.content = content;
-        validatePostImageFile(postImageFile);
-        this.postImageFile = postImageFile;
-    }
-
-    private void validatePostImageFile(MultipartFile postImageFile) {
-        if (postImageFile == null || postImageFile.isEmpty()) {
-            throw new ImageFileNotExistsException();
-        }
-    }
+public record PostCreateRequest(@NotBlank String content, @NotNull MultipartFile postImageFile) {
 }

--- a/src/main/java/com/numble/instagram/dto/request/post/PostCreateRequest.java
+++ b/src/main/java/com/numble/instagram/dto/request/post/PostCreateRequest.java
@@ -6,13 +6,13 @@ import org.springframework.web.multipart.MultipartFile;
 
 public record PostCreateRequest(@NotBlank String content, MultipartFile postImageFile) {
 
-    public PostCreateRequest(@NotBlank String content, MultipartFile postImageFile) {
+    public PostCreateRequest(String content, MultipartFile postImageFile) {
         this.content = content;
-        validatePostImageFile();
+        validatePostImageFile(postImageFile);
         this.postImageFile = postImageFile;
     }
 
-    private void validatePostImageFile() {
+    private void validatePostImageFile(MultipartFile postImageFile) {
         if (postImageFile == null || postImageFile.isEmpty()) {
             throw new ImageFileNotExistsException();
         }

--- a/src/main/java/com/numble/instagram/dto/request/post/PostCreateRequest.java
+++ b/src/main/java/com/numble/instagram/dto/request/post/PostCreateRequest.java
@@ -1,0 +1,20 @@
+package com.numble.instagram.dto.request.post;
+
+import com.numble.instagram.exception.badrequest.ImageFileNotExistsException;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.web.multipart.MultipartFile;
+
+public record PostCreateRequest(@NotBlank String content, MultipartFile postImageFile) {
+
+    public PostCreateRequest(@NotBlank String content, MultipartFile postImageFile) {
+        this.content = content;
+        validatePostImageFile();
+        this.postImageFile = postImageFile;
+    }
+
+    private void validatePostImageFile() {
+        if (postImageFile == null || postImageFile.isEmpty()) {
+            throw new ImageFileNotExistsException();
+        }
+    }
+}

--- a/src/main/java/com/numble/instagram/dto/request/post/PostEditRequest.java
+++ b/src/main/java/com/numble/instagram/dto/request/post/PostEditRequest.java
@@ -1,0 +1,7 @@
+package com.numble.instagram.dto.request.post;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.web.multipart.MultipartFile;
+
+public record PostEditRequest(@NotBlank String content, MultipartFile postImageFile) {
+}

--- a/src/main/java/com/numble/instagram/dto/response/post/PostResponse.java
+++ b/src/main/java/com/numble/instagram/dto/response/post/PostResponse.java
@@ -1,0 +1,13 @@
+package com.numble.instagram.dto.response.post;
+
+import com.numble.instagram.domain.post.entity.Post;
+
+import java.time.LocalDateTime;
+
+public record PostResponse(Long id, String postImageUrl, String content, Long likeCount, LocalDateTime createdAt) {
+
+    public static PostResponse from(Post post) {
+        return new PostResponse(
+                post.getId(), post.getPostImageUrl(), post.getContent(), post.getLikeCount(), post.getCreatedAt());
+    }
+}

--- a/src/main/java/com/numble/instagram/exception/badrequest/ImageFileNotExistsException.java
+++ b/src/main/java/com/numble/instagram/exception/badrequest/ImageFileNotExistsException.java
@@ -1,0 +1,8 @@
+package com.numble.instagram.exception.badrequest;
+
+public class ImageFileNotExistsException extends InvalidRequestException {
+
+    public ImageFileNotExistsException() {
+        addValidation("multipartFile", "파일이 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/numble/instagram/exception/badrequest/NotPostWriterException.java
+++ b/src/main/java/com/numble/instagram/exception/badrequest/NotPostWriterException.java
@@ -1,0 +1,8 @@
+package com.numble.instagram.exception.badrequest;
+
+public class NotPostWriterException extends InvalidRequestException {
+
+    public NotPostWriterException() {
+        addValidation("user", "글 작성자가 아닙니다.");
+    }
+}

--- a/src/main/java/com/numble/instagram/exception/notfound/PostNotFoundException.java
+++ b/src/main/java/com/numble/instagram/exception/notfound/PostNotFoundException.java
@@ -1,0 +1,8 @@
+package com.numble.instagram.exception.notfound;
+
+public class PostNotFoundException extends NotFoundException {
+
+    public PostNotFoundException() {
+        addValidation("post", "post를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/numble/instagram/presentation/post/PostController.java
+++ b/src/main/java/com/numble/instagram/presentation/post/PostController.java
@@ -1,0 +1,28 @@
+package com.numble.instagram.presentation.post;
+
+import com.numble.instagram.application.usecase.post.CreatePostUsecase;
+import com.numble.instagram.dto.request.post.PostCreateRequest;
+import com.numble.instagram.presentation.auth.AuthenticatedUser;
+import com.numble.instagram.presentation.auth.Login;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/post")
+public class PostController {
+
+    private final CreatePostUsecase createPostUsecase;
+
+    @Login
+    @PostMapping
+    public String register(@AuthenticatedUser Long userId,
+                           @Validated PostCreateRequest postCreateRequest) {
+        createPostUsecase.execute(userId, postCreateRequest);
+
+        return "il";
+    }
+}

--- a/src/main/java/com/numble/instagram/presentation/post/PostController.java
+++ b/src/main/java/com/numble/instagram/presentation/post/PostController.java
@@ -1,12 +1,15 @@
 package com.numble.instagram.presentation.post;
 
 import com.numble.instagram.application.usecase.post.CreatePostUsecase;
+import com.numble.instagram.application.usecase.post.EditPostUsecase;
 import com.numble.instagram.dto.request.post.PostCreateRequest;
+import com.numble.instagram.dto.request.post.PostEditRequest;
 import com.numble.instagram.dto.response.post.PostResponse;
 import com.numble.instagram.presentation.auth.AuthenticatedUser;
 import com.numble.instagram.presentation.auth.Login;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,11 +20,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
     private final CreatePostUsecase createPostUsecase;
+    private final EditPostUsecase editPostUsecase;
 
     @Login
     @PostMapping
     public PostResponse register(@AuthenticatedUser Long userId,
                                  @Validated PostCreateRequest postCreateRequest) {
         return createPostUsecase.execute(userId, postCreateRequest);
+    }
+
+    @Login
+    @PostMapping("/{postId}/edit")
+    public PostResponse edit(@AuthenticatedUser Long userId,
+                             @PathVariable Long postId,
+                             @Validated PostEditRequest postEditRequest) {
+        return editPostUsecase.execute(userId, postId, postEditRequest);
     }
 }

--- a/src/main/java/com/numble/instagram/presentation/post/PostController.java
+++ b/src/main/java/com/numble/instagram/presentation/post/PostController.java
@@ -2,6 +2,7 @@ package com.numble.instagram.presentation.post;
 
 import com.numble.instagram.application.usecase.post.CreatePostUsecase;
 import com.numble.instagram.dto.request.post.PostCreateRequest;
+import com.numble.instagram.dto.response.post.PostResponse;
 import com.numble.instagram.presentation.auth.AuthenticatedUser;
 import com.numble.instagram.presentation.auth.Login;
 import lombok.RequiredArgsConstructor;
@@ -19,10 +20,8 @@ public class PostController {
 
     @Login
     @PostMapping
-    public String register(@AuthenticatedUser Long userId,
-                           @Validated PostCreateRequest postCreateRequest) {
-        createPostUsecase.execute(userId, postCreateRequest);
-
-        return "il";
+    public PostResponse register(@AuthenticatedUser Long userId,
+                                 @Validated PostCreateRequest postCreateRequest) {
+        return createPostUsecase.execute(userId, postCreateRequest);
     }
 }

--- a/src/test/java/com/numble/instagram/application/usecase/post/CreatePostUsecaseTest.java
+++ b/src/test/java/com/numble/instagram/application/usecase/post/CreatePostUsecaseTest.java
@@ -1,0 +1,80 @@
+package com.numble.instagram.application.usecase.post;
+
+import com.numble.instagram.domain.follow.entity.Follow;
+import com.numble.instagram.domain.follow.service.FollowReadService;
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.post.service.FeedWriteService;
+import com.numble.instagram.domain.post.service.PostWriteService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.request.post.PostCreateRequest;
+import com.numble.instagram.dto.response.post.PostResponse;
+import com.numble.instagram.support.file.FileStore;
+import com.numble.instagram.util.fixture.post.PostFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreatePostUsecaseTest {
+
+    @Mock
+    private UserReadService userReadService;
+    @Mock
+    private PostWriteService postWriteService;
+    @Mock
+    private FollowReadService followReadService;
+    @Mock
+    private FeedWriteService feedWriteService;
+    @Mock
+    private FileStore fileStore;
+    @InjectMocks
+    private CreatePostUsecase createPostUsecase;
+
+    @Test
+    @DisplayName("글을 생성하는 유즈케이스 테스트")
+    void execute_createPost() {
+        Long userId = 1L;
+        User writerUser = UserFixture.create(userId, "writerUser");
+
+        MultipartFile postImageFile = new MockMultipartFile(
+                "test.jpg", "test.jpg", "image/jpeg", "test.jpg".getBytes());
+        PostCreateRequest postCreateRequest = new PostCreateRequest("test post", postImageFile);
+
+        String postImageUrl = "https://example.com/test.jpg";
+
+        Post newPost = PostFixture.create(postImageUrl, postCreateRequest.content(), writerUser);
+
+        User follower1 = UserFixture.create(2L, "follower1");
+        User follower2 = UserFixture.create(3L, "follower2");
+        List<User> followers = List.of(follower1, follower2);
+
+        when(userReadService.getUser(userId)).thenReturn(writerUser);
+        when(fileStore.uploadImage(postCreateRequest.postImageFile())).thenReturn(postImageUrl);
+        when(postWriteService.register(writerUser, postCreateRequest.content(), postImageUrl)).thenReturn(newPost);
+        when(followReadService.getFollowersFollow(writerUser)).thenReturn(
+                List.of(Follow.create(follower1, writerUser), Follow.create(follower2, writerUser))
+        );
+
+        PostResponse postResponse = createPostUsecase.execute(userId, postCreateRequest);
+
+        verify(postWriteService).register(writerUser, postCreateRequest.content(), postImageUrl);
+        verify(followReadService).getFollowersFollow(writerUser);
+        verify(feedWriteService).deliveryToFeed(newPost, followers);
+        verifyNoMoreInteractions(postWriteService, followReadService, feedWriteService);
+
+        PostResponse expectedResponse = PostResponse.from(newPost);
+        assertEquals(expectedResponse, postResponse);
+    }
+}

--- a/src/test/java/com/numble/instagram/application/usecase/post/EditPostUsecaseTest.java
+++ b/src/test/java/com/numble/instagram/application/usecase/post/EditPostUsecaseTest.java
@@ -1,0 +1,85 @@
+package com.numble.instagram.application.usecase.post;
+
+import com.numble.instagram.domain.post.dto.PostDto;
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.post.service.PostWriteService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.request.post.PostEditRequest;
+import com.numble.instagram.dto.response.post.PostResponse;
+import com.numble.instagram.support.file.FileStore;
+import com.numble.instagram.util.fixture.post.PostFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EditPostUsecaseTest {
+
+    @Mock
+    private UserReadService userReadService;
+
+    @Mock
+    private PostWriteService postWriteService;
+
+    @Mock
+    private FileStore fileStore;
+
+    @InjectMocks
+    private EditPostUsecase editPostUsecase;
+
+    @Test
+    @DisplayName("이미지가 있을 때 글 수정")
+    void executeWithImage() {
+        Long userId = 1L;
+        Long postId = 2L;
+        String newContent = "new content";
+        String newImageUrl = "https://new-image.jpg";
+        MultipartFile postImageFile = new MockMultipartFile("test-image.jpg", "test.jpg".getBytes());
+        PostEditRequest postEditRequest = new PostEditRequest("new content", postImageFile);
+        User writer = UserFixture.create(userId, "writer");
+        Post editedPost = PostFixture.create("https://new-image.jpg", newContent, writer);
+        PostDto editedPostDto = PostDto.from(editedPost, "https://old-image.jpg");
+
+
+        when(userReadService.getUser(userId)).thenReturn(writer);
+        when(postWriteService.edit(writer, postId, newContent, newImageUrl)).thenReturn(editedPostDto);
+        when(fileStore.uploadImage(postImageFile)).thenReturn(newImageUrl);
+
+        PostResponse postResponse = editPostUsecase.execute(userId, postId, postEditRequest);
+
+        assertEquals(newContent, postResponse.content());
+        assertEquals(newImageUrl, postResponse.postImageUrl());
+    }
+
+    @Test
+    @DisplayName("이미지가 없을 때 글 수정")
+    void executeWithoutImage() {
+        Long userId = 1L;
+        Long postId = 2L;
+        String newContent = "new content";
+        PostEditRequest postEditRequest = new PostEditRequest("new content", null);
+        User writer = UserFixture.create(userId, "writer");
+        String oldImageUrl = "https://old-image.jpg";
+        Post editedPost = PostFixture.create(oldImageUrl, newContent, writer);
+        PostDto editedPostDto = PostDto.from(editedPost, null);
+
+        when(userReadService.getUser(userId)).thenReturn(writer);
+        when(postWriteService.edit(writer, postId, newContent, null)).thenReturn(editedPostDto);
+
+        PostResponse postResponse = editPostUsecase.execute(userId, postId, postEditRequest);
+
+        assertEquals(newContent, postResponse.content());
+        assertEquals(oldImageUrl, postResponse.postImageUrl());
+        verify(fileStore, never()).deleteFile(anyString());
+    }
+}

--- a/src/test/java/com/numble/instagram/domain/follow/service/FollowReadServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/follow/service/FollowReadServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.stream.LongStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
+@Transactional
 class FollowReadServiceTest {
 
     @Autowired

--- a/src/test/java/com/numble/instagram/domain/post/service/FeedWriteServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/post/service/FeedWriteServiceTest.java
@@ -1,0 +1,47 @@
+package com.numble.instagram.domain.post.service;
+
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.post.repository.FeedRepository;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.util.fixture.post.PostFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class FeedWriteServiceTest {
+
+    @Mock
+    private FeedRepository feedRepository;
+
+    @InjectMocks
+    private FeedWriteService feedWriteService;
+
+    @Test
+    @DisplayName("post는 feed로 배달된다.")
+    void deliveryToFeed() {
+        User writerUser = UserFixture.create("writerUser");
+        List<User> followers = new LinkedList<>();
+        IntStream.range(1, 20).forEach(i -> {
+            User user = UserFixture.create("user" + i);
+            followers.add(user);
+        });
+
+        Post newPost = PostFixture.create("imageUrl", "content", writerUser);
+
+        feedWriteService.deliveryToFeed(newPost, followers);
+
+        Mockito.verify(feedRepository).saveAll(any(List.class));
+    }
+}

--- a/src/test/java/com/numble/instagram/domain/post/service/PostWriteServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/post/service/PostWriteServiceTest.java
@@ -1,8 +1,11 @@
 package com.numble.instagram.domain.post.service;
 
+import com.numble.instagram.domain.post.dto.PostDto;
 import com.numble.instagram.domain.post.entity.Post;
 import com.numble.instagram.domain.post.repository.PostRepository;
 import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.exception.badrequest.NotPostWriterException;
+import com.numble.instagram.exception.notfound.PostNotFoundException;
 import com.numble.instagram.util.fixture.post.PostFixture;
 import com.numble.instagram.util.fixture.user.UserFixture;
 import org.junit.jupiter.api.DisplayName;
@@ -12,7 +15,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -38,5 +43,61 @@ class PostWriteServiceTest {
         assertEquals(writerUser, newPost.getWriterUser());
         assertEquals(content, newPost.getContent());
         assertEquals(postImageUrl, newPost.getPostImageUrl());
+    }
+
+    @Test
+    @DisplayName("글을 수정한다.")
+    void edit() {
+        User writerUser = UserFixture.create("writerUser");
+        String newContent = "new content";
+        String newImageUrl = "https://newImage.jpg";
+        Post post = PostFixture.create("https://oldImage.jpg", "old content", writerUser);
+        when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+
+        PostDto result = postWriteService.edit(writerUser, post.getId(), newContent, newImageUrl);
+
+        assertEquals(post.getId(), result.post().getId());
+        assertEquals(post.getContent(), newContent);
+        assertEquals(post.getPostImageUrl(), newImageUrl);
+        assertEquals("https://oldImage.jpg", result.willDeleteImageUrl());
+    }
+
+    @Test
+    @DisplayName("글을 이미지없이 수정한다.")
+    void editWithOnlyContent() {
+        User writerUser = UserFixture.create("writerUser");
+        String newContent = "new content";
+        Post post = PostFixture.create("https://oldImage.jpg", "old content", writerUser);
+        when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+
+        PostDto result = postWriteService.edit(writerUser, post.getId(), newContent, null);
+
+        assertEquals(post.getId(), result.post().getId());
+        assertEquals(post.getContent(), newContent);
+        assertEquals("https://oldImage.jpg", result.post().getPostImageUrl());
+        assertNull(result.willDeleteImageUrl());
+    }
+
+    @Test
+    @DisplayName("post가 없으면 PostNotFoundException이 발생한다.")
+    void postNotFound() {
+        User writerUser = UserFixture.create("writerUser");
+        Long nonExistingPostId = 2L;
+        when(postRepository.findById(nonExistingPostId)).thenReturn(Optional.empty());
+
+        assertThrows(PostNotFoundException.class,
+                () -> postWriteService.edit(writerUser, nonExistingPostId, "new content", null));
+    }
+
+    @Test
+    @DisplayName("수정을 시도한 user가 writer이 아니면 NotPostWriterException이 발생한다.")
+    void notPostWriter() {
+        User writerUser = UserFixture.create("writerUser");
+        Post post = PostFixture.create("https://oldImage.jpg", "old content", writerUser);
+        when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+
+        User notWriter = UserFixture.create("notWriter");
+        assertThrows(NotPostWriterException.class,
+                () -> postWriteService.edit(notWriter, post.getId(), "new content", "http://newImage"));
     }
 }

--- a/src/test/java/com/numble/instagram/domain/post/service/PostWriteServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/post/service/PostWriteServiceTest.java
@@ -1,0 +1,42 @@
+package com.numble.instagram.domain.post.service;
+
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.post.repository.PostRepository;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.util.fixture.post.PostFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PostWriteServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private PostWriteService postWriteService;
+
+    @Test
+    @DisplayName("글을 등록한다.")
+    void register() {
+        User writerUser = UserFixture.create("writerUser");
+        String content = "post content";
+        String postImageUrl = "http://example.com/image.jpg";
+        when(postRepository.save(any(Post.class))).thenReturn(PostFixture.create(postImageUrl, content, writerUser));
+
+        Post newPost = postWriteService.register(writerUser, content, postImageUrl);
+
+        assertEquals(writerUser, newPost.getWriterUser());
+        assertEquals(content, newPost.getContent());
+        assertEquals(postImageUrl, newPost.getPostImageUrl());
+    }
+}

--- a/src/test/java/com/numble/instagram/presentation/post/PostControllerDocsTest.java
+++ b/src/test/java/com/numble/instagram/presentation/post/PostControllerDocsTest.java
@@ -1,0 +1,96 @@
+package com.numble.instagram.presentation.post;
+
+import com.numble.instagram.application.auth.token.TokenProvider;
+import com.numble.instagram.application.usecase.post.CreatePostUsecase;
+import com.numble.instagram.dto.request.post.PostCreateRequest;
+import com.numble.instagram.dto.response.post.PostResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
+class PostControllerDocsTest {
+
+    private MockMvc mockMvc;
+    @MockBean
+    private TokenProvider tokenProvider;
+    @MockBean
+    private CreatePostUsecase createPostUsecase;
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+    private static final String DOCUMENT_IDENTIFIER = "post/{method-name}/";
+    MockMultipartFile postImageFile = new MockMultipartFile("postImageFile", "image".getBytes());
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint(), modifyHeaders().remove("Vary")))
+                .build();
+    }
+
+    @Test
+    @DisplayName("글은 등록되어야 한다.")
+    void register() throws Exception {
+        String authorizationHeader = "Bearer access-token";
+        Long userId = 1L;
+        given(tokenProvider.isValidToken(authorizationHeader)).willReturn(true);
+        given(tokenProvider.getUserId(authorizationHeader)).willReturn(userId);
+
+        String content = "내용입니다.";
+        PostCreateRequest postCreateRequest = new PostCreateRequest(content, postImageFile);
+        PostResponse postResponse = new PostResponse(
+                1L, "https://postImage.jpg", content, 0L, LocalDateTime.now());
+        given(createPostUsecase.execute(eq(userId), eq(postCreateRequest))).willReturn(postResponse);
+
+        mockMvc.perform(multipart("/api/post")
+                        .file(postImageFile)
+                        .param("content", content)
+                        .header(HttpHeaders.AUTHORIZATION, authorizationHeader))
+                .andExpect(status().isOk())
+                .andDo(document(DOCUMENT_IDENTIFIER,
+                        requestParts(
+                                partWithName("postImageFile").description("파일 업로드")
+                        ),
+//                        formParameters(
+//                                parameterWithName("content").description("글 내용")
+//                        ),
+                        responseFields(
+                                fieldWithPath("id").description("post id"),
+                                fieldWithPath("postImageUrl").description("글 이미지 Url"),
+                                fieldWithPath("content").description("내용"),
+                                fieldWithPath("likeCount").description("좋아요 수"),
+                                fieldWithPath("createdAt").description("글 쓴 날짜")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/numble/instagram/util/fixture/post/PostFixture.java
+++ b/src/test/java/com/numble/instagram/util/fixture/post/PostFixture.java
@@ -1,0 +1,45 @@
+package com.numble.instagram.util.fixture.post;
+
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.user.entity.User;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+
+import java.time.LocalDate;
+
+import static org.jeasy.random.FieldPredicates.*;
+
+public class PostFixture {
+
+    public static Post create(String postImageUrl, String content, User writerUser) {
+        var idPredicate = named("id")
+                .and(ofType(Long.class))
+                .and(inClass(Post.class));
+
+        var postImageUrlPredicate = named("postImageUrl")
+                .and(ofType(String.class))
+                .and(inClass(Post.class));
+
+        var contentPredicate = named("content")
+                .and(ofType(String.class))
+                .and(inClass(Post.class));
+
+        var writerUserPredicate = named("writerUser")
+                .and(ofType(User.class))
+                .and(inClass(Post.class));
+
+        var likeCountPredicate = named("likeCount")
+                .and(ofType(Long.class))
+                .and(inClass(Post.class));
+
+        var param = new EasyRandomParameters()
+                .randomize(postImageUrlPredicate, () -> postImageUrl)
+                .randomize(contentPredicate, () -> content)
+                .randomize(writerUserPredicate, () -> writerUser)
+                .randomize(likeCountPredicate, () -> 0L)
+                .dateRange(LocalDate.now(), LocalDate.now())
+                .excludeField(idPredicate);
+
+        return new EasyRandom(param).nextObject(Post.class);
+    }
+}


### PR DESCRIPTION
## 작업 주제

- 글 생성, 글 수정 기능을 구현합니다.

## optional 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 글을 생성할 때는 Post table과 Feed table에 insert를 하는 과정을 코드로 작성했습니다.
- Feed table을 따로 두는 이유는 인스타그램의 특성상 글을 쓰는 것보다 피드를 조회하는 일이 더 많다고 느껴졌기 때문입니다. 
- 글 작성시 DB에 부하가 발생하긴하지만 그만큼 조회시에는 성능상에 이점을 얻을 수 있을거라고 판단했습니다. 
- 현재 jpa로 bulkInsert 를 saveAll로 진행하고 있는데 추후 변경할 예정입니다.  (procedure 이용을 추천받은 상태, jdbcTemplate로 할 예정이었음)
- 글 수정에서는 content는 무조건 클라이언트에서 요청보낸다고 생각하고, imageFile은 요청을 보내면 업데이트하고 없으면 원래의 이미지Url을 유지하는 방향으로 구현했습니다.

## optional 관련 Docs
- [Write-based fan-out vs read-based fan-out](https://rubanm.tumblr.com/post/59561467766/write-based-fan-out-vs-read-based-fan-out)
- 흥미로운 포스팅을 읽게 되었습니다. 트위터와 페이스북의 아키텍처가 각각 서로 다르네요. 페이스북은 Fan Out On Read를 트위터는 Fan Out on Write을 사용하는 것 같습니다. 조금 더 기술적으로 공부하고 고민해봐야하는 문제 같습니다.

## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [x] base, compare branch가 적절하게 선택되었나요?
- [x] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)