### PR TITLE
팔로잉 목록과 팔로워 목록 조회한 유저만 나오는 현상, 팔로워, 팔로잉 목록 조회시 n + 1 문제

### DIFF
--- a/src/main/java/com/numble/instagram/application/usecase/post/CreatePostUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/post/CreatePostUsecase.java
@@ -30,7 +30,7 @@ public class CreatePostUsecase {
         String postImageUrl = fileStore.uploadImage(postCreateRequest.postImageFile());
 
         Post newPost = postWriteService.register(writerUser, postCreateRequest.content(), postImageUrl);
-        List<User> followers = followReadService.getFollowersFollow(writerUser).stream()
+        List<User> followers = followReadService.getFollowersFollow(writerUser.getId()).stream()
                 .map(Follow::getFromUser)
                 .toList();
 

--- a/src/main/java/com/numble/instagram/application/usecase/user/GetFollowersUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/user/GetFollowersUsecase.java
@@ -20,7 +20,7 @@ public class GetFollowersUsecase {
 
     public List<UserResponse> execute(Long userId) {
         User user = userReadService.getUser(userId);
-        return followReadService.getFollowersFollow(user).stream()
+        return followReadService.getFollowersFollow(user.getId()).stream()
                 .map(Follow::getFromUser)
                 .map(UserResponse::from)
                 .sorted(Comparator.comparing(UserResponse::nickname))

--- a/src/main/java/com/numble/instagram/application/usecase/user/GetFollowersUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/user/GetFollowersUsecase.java
@@ -21,7 +21,7 @@ public class GetFollowersUsecase {
     public List<UserResponse> execute(Long userId) {
         User user = userReadService.getUser(userId);
         return followReadService.getFollowersFollow(user).stream()
-                .map(Follow::getToUser)
+                .map(Follow::getFromUser)
                 .map(UserResponse::from)
                 .sorted(Comparator.comparing(UserResponse::nickname))
                 .toList();

--- a/src/main/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecase.java
@@ -21,7 +21,7 @@ public class GetFollowingsUsecase {
     public List<UserResponse> execute(Long userId) {
         User user = userReadService.getUser(userId);
         return followReadService.getFollowingsFollow(user).stream()
-                .map(Follow::getFromUser)
+                .map(Follow::getToUser)
                 .map(UserResponse::from)
                 .sorted(Comparator.comparing(UserResponse::nickname))
                 .toList();

--- a/src/main/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecase.java
@@ -20,7 +20,7 @@ public class GetFollowingsUsecase {
 
     public List<UserResponse> execute(Long userId) {
         User user = userReadService.getUser(userId);
-        return followReadService.getFollowingsFollow(user).stream()
+        return followReadService.getFollowingsFollow(user.getId()).stream()
                 .map(Follow::getToUser)
                 .map(UserResponse::from)
                 .sorted(Comparator.comparing(UserResponse::nickname))

--- a/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
@@ -3,6 +3,8 @@ package com.numble.instagram.domain.follow.repository;
 import com.numble.instagram.domain.follow.entity.Follow;
 import com.numble.instagram.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,6 +12,10 @@ import java.util.Optional;
 public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRepositoryCustom {
 
     Optional<Follow> findByFromUserAndToUser(User fromUser, User toUser);
-    List<Follow> findByToUser(User toUser);
-    List<Follow> findByFromUser(User fromUser);
+
+    @Query("SELECT f FROM Follow f JOIN f.fromUser fu JOIN f.toUser tu WHERE fu.id = :userId")
+    List<Follow> findByToUser(@Param("userId") Long userId);
+
+    @Query("SELECT f FROM Follow f JOIN f.toUser fu JOIN f.fromUser tu WHERE fu.id = :userId")
+    List<Follow> findByFromUser(@Param("userId") Long userId);
 }

--- a/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
@@ -14,7 +14,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRep
     Optional<Follow> findByFromUserAndToUser(User fromUser, User toUser);
 
     @Query("SELECT f FROM Follow f JOIN FETCH f.fromUser WHERE f.toUser.id = :userId")
-    List<Follow> findByToUser(@Param("userId") Long userId);
+    List<Follow> findByToUserIdWithFromUser(@Param("userId") Long userId);
 
     @Query("SELECT f FROM Follow f JOIN FETCH f.toUser WHERE f.fromUser.id = :userId")
     List<Follow> findByFromUserIdWithToUser(@Param("userId") Long userId);

--- a/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
@@ -13,9 +13,9 @@ public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRep
 
     Optional<Follow> findByFromUserAndToUser(User fromUser, User toUser);
 
-    @Query("SELECT f FROM Follow f JOIN f.toUser fu JOIN f.fromUser tu WHERE fu.id = :userId")
+    @Query("SELECT f FROM Follow f JOIN FETCH f.fromUser WHERE f.toUser.id = :userId")
     List<Follow> findByToUser(@Param("userId") Long userId);
 
-    @Query("SELECT f FROM Follow f JOIN f.fromUser fu JOIN f.toUser tu WHERE fu.id = :userId")
-    List<Follow> findByFromUser(@Param("userId") Long userId);
+    @Query("SELECT f FROM Follow f JOIN FETCH f.toUser WHERE f.fromUser.id = :userId")
+    List<Follow> findByFromUserIdWithToUser(@Param("userId") Long userId);
 }

--- a/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/numble/instagram/domain/follow/repository/FollowRepository.java
@@ -13,9 +13,9 @@ public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRep
 
     Optional<Follow> findByFromUserAndToUser(User fromUser, User toUser);
 
-    @Query("SELECT f FROM Follow f JOIN f.fromUser fu JOIN f.toUser tu WHERE fu.id = :userId")
+    @Query("SELECT f FROM Follow f JOIN f.toUser fu JOIN f.fromUser tu WHERE fu.id = :userId")
     List<Follow> findByToUser(@Param("userId") Long userId);
 
-    @Query("SELECT f FROM Follow f JOIN f.toUser fu JOIN f.fromUser tu WHERE fu.id = :userId")
+    @Query("SELECT f FROM Follow f JOIN f.fromUser fu JOIN f.toUser tu WHERE fu.id = :userId")
     List<Follow> findByFromUser(@Param("userId") Long userId);
 }

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
@@ -25,10 +25,10 @@ public class FollowReadService {
     }
 
     public List<Follow> getFollowersFollow(User toUser) {
-        return followRepository.findByToUser(toUser);
+        return followRepository.findByToUser(toUser.getId());
     }
 
     public List<Follow> getFollowingsFollow(User fromUser) {
-        return followRepository.findByFromUser(fromUser);
+        return followRepository.findByFromUser(fromUser.getId());
     }
 }

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
@@ -28,6 +28,6 @@ public class FollowReadService {
     }
 
     public List<Follow> getFollowingsFollow(Long fromUserId) {
-        return followRepository.findByFromUser(fromUserId);
+        return followRepository.findByFromUserIdWithToUser(fromUserId);
     }
 }

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
@@ -2,7 +2,6 @@ package com.numble.instagram.domain.follow.service;
 
 import com.numble.instagram.domain.follow.entity.Follow;
 import com.numble.instagram.domain.follow.repository.FollowRepository;
-import com.numble.instagram.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,11 +23,11 @@ public class FollowReadService {
         return followRepository.getFollowingCount(userId);
     }
 
-    public List<Follow> getFollowersFollow(User toUser) {
-        return followRepository.findByToUser(toUser.getId());
+    public List<Follow> getFollowersFollow(Long toUserId) {
+        return followRepository.findByToUser(toUserId);
     }
 
-    public List<Follow> getFollowingsFollow(User fromUser) {
-        return followRepository.findByFromUser(fromUser.getId());
+    public List<Follow> getFollowingsFollow(Long fromUserId) {
+        return followRepository.findByFromUser(fromUserId);
     }
 }

--- a/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
+++ b/src/main/java/com/numble/instagram/domain/follow/service/FollowReadService.java
@@ -24,7 +24,7 @@ public class FollowReadService {
     }
 
     public List<Follow> getFollowersFollow(Long toUserId) {
-        return followRepository.findByToUser(toUserId);
+        return followRepository.findByToUserIdWithFromUser(toUserId);
     }
 
     public List<Follow> getFollowingsFollow(Long fromUserId) {

--- a/src/test/java/com/numble/instagram/application/usecase/post/CreatePostUsecaseTest.java
+++ b/src/test/java/com/numble/instagram/application/usecase/post/CreatePostUsecaseTest.java
@@ -63,14 +63,14 @@ class CreatePostUsecaseTest {
         when(userReadService.getUser(userId)).thenReturn(writerUser);
         when(fileStore.uploadImage(postCreateRequest.postImageFile())).thenReturn(postImageUrl);
         when(postWriteService.register(writerUser, postCreateRequest.content(), postImageUrl)).thenReturn(newPost);
-        when(followReadService.getFollowersFollow(writerUser)).thenReturn(
+        when(followReadService.getFollowersFollow(writerUser.getId())).thenReturn(
                 List.of(Follow.create(follower1, writerUser), Follow.create(follower2, writerUser))
         );
 
         PostResponse postResponse = createPostUsecase.execute(userId, postCreateRequest);
 
         verify(postWriteService).register(writerUser, postCreateRequest.content(), postImageUrl);
-        verify(followReadService).getFollowersFollow(writerUser);
+        verify(followReadService).getFollowersFollow(writerUser.getId());
         verify(feedWriteService).deliveryToFeed(newPost, followers);
         verifyNoMoreInteractions(postWriteService, followReadService, feedWriteService);
 

--- a/src/test/java/com/numble/instagram/application/usecase/user/GetFollowersUsecaseTest.java
+++ b/src/test/java/com/numble/instagram/application/usecase/user/GetFollowersUsecaseTest.java
@@ -41,7 +41,7 @@ class GetFollowersUsecaseTest {
         Follow follow2 = FollowFixture.create(follower2, user);
         List<Follow> followList = List.of(follow1, follow2);
         when(userReadService.getUser(user.getId())).thenReturn(user);
-        when(followReadService.getFollowersFollow(user)).thenReturn(followList);
+        when(followReadService.getFollowersFollow(user.getId())).thenReturn(followList);
 
         List<UserResponse> result = getFollowersUsecase.execute(user.getId());
 

--- a/src/test/java/com/numble/instagram/application/usecase/user/GetFollowersUsecaseTest.java
+++ b/src/test/java/com/numble/instagram/application/usecase/user/GetFollowersUsecaseTest.java
@@ -37,8 +37,8 @@ class GetFollowersUsecaseTest {
         User user = UserFixture.create("user1");
         User follower1 = UserFixture.create("follower1");
         User follower2 = UserFixture.create("follower2");
-        Follow follow1 = FollowFixture.create(user, follower1);
-        Follow follow2 = FollowFixture.create(user, follower2);
+        Follow follow1 = FollowFixture.create(follower1, user);
+        Follow follow2 = FollowFixture.create(follower2, user);
         List<Follow> followList = List.of(follow1, follow2);
         when(userReadService.getUser(user.getId())).thenReturn(user);
         when(followReadService.getFollowersFollow(user)).thenReturn(followList);

--- a/src/test/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecaseTest.java
+++ b/src/test/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecaseTest.java
@@ -37,8 +37,8 @@ class GetFollowingsUsecaseTest {
         User user = UserFixture.create("user1");
         User following1 = UserFixture.create("following1");
         User following2 = UserFixture.create("following2");
-        Follow followingFollow1 = FollowFixture.create(following1, user);
-        Follow followingFollow2 = FollowFixture.create(following2, user);
+        Follow followingFollow1 = FollowFixture.create(user, following1);
+        Follow followingFollow2 = FollowFixture.create(user, following2);
         List<Follow> followList = List.of(followingFollow1, followingFollow2);
         when(userReadService.getUser(user.getId())).thenReturn(user);
         when(followReadService.getFollowingsFollow(user)).thenReturn(followList);

--- a/src/test/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecaseTest.java
+++ b/src/test/java/com/numble/instagram/application/usecase/user/GetFollowingsUsecaseTest.java
@@ -41,7 +41,7 @@ class GetFollowingsUsecaseTest {
         Follow followingFollow2 = FollowFixture.create(user, following2);
         List<Follow> followList = List.of(followingFollow1, followingFollow2);
         when(userReadService.getUser(user.getId())).thenReturn(user);
-        when(followReadService.getFollowingsFollow(user)).thenReturn(followList);
+        when(followReadService.getFollowingsFollow(user.getId())).thenReturn(followList);
 
         List<UserResponse> result = getFollowingsUsecase.execute(user.getId());
 

--- a/src/test/java/com/numble/instagram/domain/follow/service/FollowReadServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/follow/service/FollowReadServiceTest.java
@@ -81,7 +81,7 @@ class FollowReadServiceTest {
         });
         followRepository.saveAllAndFlush(followers);
 
-        List<Follow> followersFollow = followReadService.getFollowersFollow(user);
+        List<Follow> followersFollow = followReadService.getFollowersFollow(user.getId());
 
         assertEquals(19, followersFollow.size());
     }
@@ -100,7 +100,7 @@ class FollowReadServiceTest {
         });
         followRepository.saveAllAndFlush(followings);
 
-        List<Follow> followingsFollow = followReadService.getFollowingsFollow(user);
+        List<Follow> followingsFollow = followReadService.getFollowingsFollow(user.getId());
 
         assertEquals(19, followingsFollow.size());
     }


### PR DESCRIPTION
## 작업 주제

- 팔로잉 목록과 팔로워 목록 조회한 유저만 나오는 현상, 팔로워, 팔로잉 목록 조회시 n + 1 문제

## optional 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 팔로워 목록과 팔로잉 목록을 조회하고 나서 fromUsert와 ToUser를 헷갈려서 생긴 문제를 바꿔줌으로써 해결했습니다.
- 팔로워, 팔로잉 목록을 조회할 때 fetch Join을 걸어줌으로써 목록 조회시 1번의 select 문을 날리도록 했습니다.

## optional 화면 스크린샷

```java
public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRepositoryCustom {

    Optional<Follow> findByFromUserAndToUser(User fromUser, User toUser);

    @Query("SELECT f FROM Follow f JOIN FETCH f.fromUser WHERE f.toUser.id = :userId")
    List<Follow> findByToUserIdWithFromUser(@Param("userId") Long userId);

    @Query("SELECT f FROM Follow f JOIN FETCH f.toUser WHERE f.fromUser.id = :userId")
    List<Follow> findByFromUserIdWithToUser(@Param("userId") Long userId);
}
```

## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [x] base, compare branch가 적절하게 선택되었나요?
- [x] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)