### PR TITLE
피드 조회 기능

### DIFF
--- a/src/docs/asciidoc/feed.adoc
+++ b/src/docs/asciidoc/feed.adoc
@@ -1,0 +1,13 @@
+== *Feed*
+
+'''
+
+=== 피드 조회
+==== Request
+include::{snippets}/feed/get-feeds/http-request.adoc[]
+- query parameter
+include::{snippets}/feed/get-feeds/query-parameters.adoc[]
+==== Response
+include::{snippets}/feed/get-feeds/http-response.adoc[]
+- body
+include::{snippets}/feed/get-feeds/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -13,3 +13,5 @@ include::user.adoc[]
 include::follow.adoc[]
 
 include::post.adoc[]
+
+include::feed.adoc[]

--- a/src/main/java/com/numble/instagram/application/usecase/post/GetFeedPostsUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/post/GetFeedPostsUsecase.java
@@ -1,0 +1,47 @@
+package com.numble.instagram.application.usecase.post;
+
+import com.numble.instagram.domain.post.entity.Feed;
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.post.service.FeedReadService;
+import com.numble.instagram.domain.post.service.PostLikeReadService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.response.post.PostDetailResponse;
+import com.numble.instagram.support.paging.CursorRequest;
+import com.numble.instagram.support.paging.PageCursor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Iterator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetFeedPostsUsecase {
+
+    private final UserReadService userReadService;
+    private final FeedReadService feedReadService;
+    private final PostLikeReadService postLikeReadService;
+
+    public PageCursor<?> execute(Long userId, CursorRequest cursorRequest) {
+        User user = userReadService.getUser(userId);
+        List<Feed> feeds = feedReadService.getFeeds(user.getId(), cursorRequest);
+
+        Long nextKey = feeds.stream()
+                .mapToLong(Feed::getId)
+                .min()
+                .orElse(CursorRequest.NONE_KEY);
+
+        List<Post> posts = feeds.stream()
+                .map(Feed::getPost)
+                .toList();
+
+        Iterator<Boolean> isPostLikedIterator = postLikeReadService.getPostLike(user, posts).iterator();
+
+        List<PostDetailResponse> postDetailResponses = posts.stream()
+                .map(post -> PostDetailResponse.from(post, isPostLikedIterator.next()))
+                .toList();
+
+        return PageCursor.from(cursorRequest.next(nextKey), postDetailResponses);
+    }
+}

--- a/src/main/java/com/numble/instagram/application/usecase/post/GetFeedPostsUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/post/GetFeedPostsUsecase.java
@@ -23,7 +23,7 @@ public class GetFeedPostsUsecase {
     private final FeedReadService feedReadService;
     private final PostLikeReadService postLikeReadService;
 
-    public PageCursor<?> execute(Long userId, CursorRequest cursorRequest) {
+    public PageCursor<PostDetailResponse> execute(Long userId, CursorRequest cursorRequest) {
         User user = userReadService.getUser(userId);
         List<Feed> feeds = feedReadService.getFeeds(user.getId(), cursorRequest);
 

--- a/src/main/java/com/numble/instagram/application/usecase/post/GetFeedPostsUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/post/GetFeedPostsUsecase.java
@@ -36,7 +36,7 @@ public class GetFeedPostsUsecase {
                 .map(Feed::getPost)
                 .toList();
 
-        Iterator<Boolean> isPostLikedIterator = postLikeReadService.getPostLike(user, posts).iterator();
+        Iterator<Boolean> isPostLikedIterator = postLikeReadService.getPostLikes(user, posts).iterator();
 
         List<PostDetailResponse> postDetailResponses = posts.stream()
                 .map(post -> PostDetailResponse.from(post, isPostLikedIterator.next()))

--- a/src/main/java/com/numble/instagram/domain/post/entity/Comment.java
+++ b/src/main/java/com/numble/instagram/domain/post/entity/Comment.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -34,6 +36,9 @@ public class Comment {
 
     @Column(updatable = false)
     private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "comment", fetch = LAZY)
+    private List<Reply> replies = new ArrayList<>();
 
     @PrePersist
     private void onPrePersist() {

--- a/src/main/java/com/numble/instagram/domain/post/entity/Comment.java
+++ b/src/main/java/com/numble/instagram/domain/post/entity/Comment.java
@@ -37,7 +37,7 @@ public class Comment {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "comment", fetch = LAZY)
+    @OneToMany(mappedBy = "comment", fetch = LAZY, cascade = CascadeType.ALL)
     private List<Reply> replies = new ArrayList<>();
 
     @PrePersist
@@ -58,5 +58,9 @@ public class Comment {
 
     public void updateContent(String content) {
         this.content = this.content.equals(content) ? this.content : content;
+    }
+
+    public void addReply(Reply reply) {
+        this.replies.add(reply);
     }
 }

--- a/src/main/java/com/numble/instagram/domain/post/entity/Post.java
+++ b/src/main/java/com/numble/instagram/domain/post/entity/Post.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -38,6 +40,9 @@ public class Post {
 
     @Column(updatable = false)
     private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "post", fetch = LAZY)
+    private List<Comment> comments = new ArrayList<>();
 
     @Version
     private Long version;

--- a/src/main/java/com/numble/instagram/domain/post/entity/Post.java
+++ b/src/main/java/com/numble/instagram/domain/post/entity/Post.java
@@ -41,7 +41,7 @@ public class Post {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "post", fetch = LAZY)
+    @OneToMany(mappedBy = "post", fetch = LAZY, cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
 
     @Version
@@ -81,5 +81,9 @@ public class Post {
 
     public void decrementLikeCount() {
         this.likeCount--;
+    }
+
+    public void addComment(Comment comment) {
+        this.getComments().add(comment);
     }
 }

--- a/src/main/java/com/numble/instagram/domain/post/repository/FeedRepository.java
+++ b/src/main/java/com/numble/instagram/domain/post/repository/FeedRepository.java
@@ -3,5 +3,5 @@ package com.numble.instagram.domain.post.repository;
 import com.numble.instagram.domain.post.entity.Feed;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FeedRepository extends JpaRepository<Feed, Long> {
+public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositoryCustom {
 }

--- a/src/main/java/com/numble/instagram/domain/post/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/numble/instagram/domain/post/repository/FeedRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.numble.instagram.domain.post.repository;
+
+import com.numble.instagram.domain.post.entity.Feed;
+import com.numble.instagram.support.paging.CursorRequest;
+
+import java.util.List;
+
+public interface FeedRepositoryCustom {
+
+    List<Feed> findAllByLessThanIdAndUserId(Long userId, CursorRequest cursorRequest);
+}

--- a/src/main/java/com/numble/instagram/domain/post/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/numble/instagram/domain/post/repository/FeedRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.numble.instagram.domain.post.repository;
+
+import com.numble.instagram.domain.post.entity.Feed;
+import com.numble.instagram.support.paging.CursorRequest;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.numble.instagram.domain.post.entity.QFeed.feed;
+import static com.numble.instagram.domain.post.entity.QPost.post;
+import static com.numble.instagram.domain.user.entity.QUser.user;
+
+@RequiredArgsConstructor
+public class FeedRepositoryImpl implements FeedRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Feed> findAllByLessThanIdAndUserId(Long userId, CursorRequest cursorRequest) {
+        return jpaQueryFactory.selectFrom(feed)
+                .leftJoin(feed.post, post).fetchJoin()
+                .leftJoin(post.writeUser, user).fetchJoin()
+                .where(
+                        feed.user.id.eq(userId),
+                        lessThanFeedId(cursorRequest)
+                )
+                .orderBy(feed.createdAt.desc())
+                .limit(cursorRequest.size())
+                .fetch();
+    }
+
+    private BooleanExpression lessThanFeedId(CursorRequest cursorRequest) {
+        if (cursorRequest.hasKey()) {
+            return feed.id.lt(cursorRequest.key());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/numble/instagram/domain/post/repository/PostLikeRepository.java
@@ -4,7 +4,10 @@ import com.numble.instagram.domain.post.entity.Post;
 import com.numble.instagram.domain.post.entity.PostLike;
 import com.numble.instagram.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
@@ -12,4 +15,18 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     boolean existsByUserAndPost(User user, Post post);
 
     Optional<PostLike> findByUserAndPost(User user, Post post);
+
+    @Query("""
+            select
+                case
+                    when (select count(pl.id)
+                          from PostLike pl
+                          where pl.post = p and pl.user = :user) > 0
+                    then true
+                    else false
+                end
+            from Post p
+            where p in :posts
+    """)
+    List<Boolean> findAllByUserAndPosts(@Param("user") User user, @Param("posts") List<Post> posts);
 }

--- a/src/main/java/com/numble/instagram/domain/post/service/CommentWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/CommentWriteService.java
@@ -23,6 +23,7 @@ public class CommentWriteService {
                 .post(post)
                 .content(content)
                 .build();
+        post.addComment(newComment);
         return commentRepository.save(newComment);
     }
 

--- a/src/main/java/com/numble/instagram/domain/post/service/FeedReadService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/FeedReadService.java
@@ -1,0 +1,22 @@
+package com.numble.instagram.domain.post.service;
+
+import com.numble.instagram.domain.post.entity.Feed;
+import com.numble.instagram.domain.post.repository.FeedRepository;
+import com.numble.instagram.support.paging.CursorRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FeedReadService {
+
+    private final FeedRepository feedRepository;
+
+    public List<Feed> getFeeds(Long userId, CursorRequest request) {
+        return feedRepository.findAllByLessThanIdAndUserId(userId, request);
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/post/service/PostLikeReadService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/PostLikeReadService.java
@@ -17,9 +17,9 @@ public class PostLikeReadService {
 
     private final PostLikeRepository postLikeRepository;
 
-    public List<Boolean> getPostLike(User user, List<Post> posts) {
-        List<Boolean> isPostLike = postLikeRepository.findAllByUserAndPosts(user, posts);
-        Collections.reverse(isPostLike);
-        return isPostLike;
+    public List<Boolean> getPostLikes(User user, List<Post> posts) {
+        List<Boolean> isPostLikes = postLikeRepository.findAllByUserAndPosts(user, posts);
+        Collections.reverse(isPostLikes);
+        return isPostLikes;
     }
 }

--- a/src/main/java/com/numble/instagram/domain/post/service/PostLikeReadService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/PostLikeReadService.java
@@ -1,0 +1,25 @@
+package com.numble.instagram.domain.post.service;
+
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.post.repository.PostLikeRepository;
+import com.numble.instagram.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostLikeReadService {
+
+    private final PostLikeRepository postLikeRepository;
+
+    public List<Boolean> getPostLike(User user, List<Post> posts) {
+        List<Boolean> isPostLike = postLikeRepository.findAllByUserAndPosts(user, posts);
+        Collections.reverse(isPostLike);
+        return isPostLike;
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/post/service/ReplyWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/ReplyWriteService.java
@@ -22,6 +22,7 @@ public class ReplyWriteService {
                 .replyWriteUser(user)
                 .comment(comment)
                 .content(content).build();
+        comment.addReply(newReply);
         return replyRepository.save(newReply);
     }
 

--- a/src/main/java/com/numble/instagram/dto/response/post/CommentDetailResponse.java
+++ b/src/main/java/com/numble/instagram/dto/response/post/CommentDetailResponse.java
@@ -1,0 +1,30 @@
+package com.numble.instagram.dto.response.post;
+
+import com.numble.instagram.domain.post.entity.Comment;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record CommentDetailResponse(
+        Long commentId,
+        String content,
+        LocalDateTime createdAt,
+        Long userId,
+        String nickname,
+        String profileImageUrl,
+        List<ReplyDetailResponse> replies) {
+
+    public static CommentDetailResponse from(Comment comment) {
+        return CommentDetailResponse.builder()
+                .commentId(comment.getId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .userId(comment.getCommentWriteUser().getId())
+                .nickname(comment.getCommentWriteUser().getNickname())
+                .profileImageUrl(comment.getCommentWriteUser().getProfileImageUrl())
+                .replies(comment.getReplies().stream().map(ReplyDetailResponse::from).toList()  )
+                .build();
+    }
+}

--- a/src/main/java/com/numble/instagram/dto/response/post/PostDetailResponse.java
+++ b/src/main/java/com/numble/instagram/dto/response/post/PostDetailResponse.java
@@ -1,0 +1,39 @@
+package com.numble.instagram.dto.response.post;
+
+import com.numble.instagram.domain.post.entity.Post;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record PostDetailResponse(
+        Long postId,
+        String content,
+        String postImageUrl,
+        Long likeCount,
+        LocalDateTime createdAt,
+        LocalDate createdDate,
+        Long userId,
+        String nickname,
+        String profileImageUrl,
+        Boolean isPostLiked,
+        List<CommentDetailResponse> comments) {
+
+    public static PostDetailResponse from(Post post, Boolean isPostLiked) {
+        return PostDetailResponse.builder()
+                .postId(post.getId())
+                .content(post.getContent())
+                .postImageUrl(post.getPostImageUrl())
+                .likeCount(post.getLikeCount())
+                .createdAt(post.getCreatedAt())
+                .createdDate(post.getCreatedDate())
+                .userId(post.getWriteUser().getId())
+                .nickname(post.getWriteUser().getNickname())
+                .profileImageUrl(post.getWriteUser().getProfileImageUrl())
+                .isPostLiked(isPostLiked)
+                .comments(post.getComments().stream().map(CommentDetailResponse::from).toList())
+                .build();
+    }
+}

--- a/src/main/java/com/numble/instagram/dto/response/post/ReplyDetailResponse.java
+++ b/src/main/java/com/numble/instagram/dto/response/post/ReplyDetailResponse.java
@@ -1,0 +1,27 @@
+package com.numble.instagram.dto.response.post;
+
+import com.numble.instagram.domain.post.entity.Reply;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ReplyDetailResponse(
+        Long replyId,
+        String content,
+        LocalDateTime createdAt,
+        Long userId,
+        String nickname,
+        String profileImageUrl) {
+
+    public static ReplyDetailResponse from(Reply reply) {
+        return ReplyDetailResponse.builder()
+                .replyId(reply.getId())
+                .content(reply.getContent())
+                .createdAt(reply.getCreatedAt())
+                .userId(reply.getReplyWriteUser().getId())
+                .nickname(reply.getReplyWriteUser().getNickname())
+                .profileImageUrl(reply.getReplyWriteUser().getProfileImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/numble/instagram/presentation/post/FeedController.java
+++ b/src/main/java/com/numble/instagram/presentation/post/FeedController.java
@@ -1,6 +1,7 @@
 package com.numble.instagram.presentation.post;
 
 import com.numble.instagram.application.usecase.post.GetFeedPostsUsecase;
+import com.numble.instagram.dto.response.post.PostDetailResponse;
 import com.numble.instagram.presentation.auth.AuthenticatedUser;
 import com.numble.instagram.presentation.auth.Login;
 import com.numble.instagram.support.paging.CursorRequest;
@@ -19,8 +20,8 @@ public class FeedController {
 
     @Login
     @GetMapping
-    public PageCursor<?> getFeed(@AuthenticatedUser Long userId,
-                                 CursorRequest cursorRequest) {
+    public PageCursor<PostDetailResponse> getFeed(@AuthenticatedUser Long userId,
+                                                  CursorRequest cursorRequest) {
         return getFeedPostsUsecase.execute(userId, cursorRequest);
     }
 }

--- a/src/main/java/com/numble/instagram/presentation/post/FeedController.java
+++ b/src/main/java/com/numble/instagram/presentation/post/FeedController.java
@@ -1,0 +1,26 @@
+package com.numble.instagram.presentation.post;
+
+import com.numble.instagram.application.usecase.post.GetFeedPostsUsecase;
+import com.numble.instagram.presentation.auth.AuthenticatedUser;
+import com.numble.instagram.presentation.auth.Login;
+import com.numble.instagram.support.paging.CursorRequest;
+import com.numble.instagram.support.paging.PageCursor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/feed")
+public class FeedController {
+
+    private final GetFeedPostsUsecase getFeedPostsUsecase;
+
+    @Login
+    @GetMapping
+    public PageCursor<?> getFeed(@AuthenticatedUser Long userId,
+                                 CursorRequest cursorRequest) {
+        return getFeedPostsUsecase.execute(userId, cursorRequest);
+    }
+}

--- a/src/main/java/com/numble/instagram/support/paging/CursorRequest.java
+++ b/src/main/java/com/numble/instagram/support/paging/CursorRequest.java
@@ -1,0 +1,22 @@
+package com.numble.instagram.support.paging;
+
+public record CursorRequest(Long key, Integer size) {
+
+    public static final Long NONE_KEY = -1L;
+    private static final Integer DEFAULT_SIZE = 10;
+    private static final Integer MAX_SIZE = 100;
+
+
+    public CursorRequest(Long key, Integer size) {
+        this.key = key;
+        this.size = size == null ? DEFAULT_SIZE : Math.min(size, MAX_SIZE);
+    }
+
+    public Boolean hasKey() {
+        return key != null && !key.equals(NONE_KEY);
+    }
+
+    public CursorRequest next(Long key) {
+        return new CursorRequest(key, size);
+    }
+}

--- a/src/main/java/com/numble/instagram/support/paging/PageCursor.java
+++ b/src/main/java/com/numble/instagram/support/paging/PageCursor.java
@@ -1,0 +1,6 @@
+package com.numble.instagram.support.paging;
+
+import java.util.List;
+
+public record PageCursor<T>(CursorRequest nextCursorRequest, List<T> body) {
+}

--- a/src/main/java/com/numble/instagram/support/paging/PageCursor.java
+++ b/src/main/java/com/numble/instagram/support/paging/PageCursor.java
@@ -3,4 +3,8 @@ package com.numble.instagram.support.paging;
 import java.util.List;
 
 public record PageCursor<T>(CursorRequest nextCursorRequest, List<T> body) {
+
+    public static PageCursor<?> from(CursorRequest nextCursorRequest, List<?> body) {
+        return new PageCursor<>(nextCursorRequest, body);
+    }
 }

--- a/src/main/java/com/numble/instagram/support/paging/PageCursor.java
+++ b/src/main/java/com/numble/instagram/support/paging/PageCursor.java
@@ -1,10 +1,12 @@
 package com.numble.instagram.support.paging;
 
+import com.numble.instagram.dto.response.post.PostDetailResponse;
+
 import java.util.List;
 
-public record PageCursor<T>(CursorRequest nextCursorRequest, List<T> body) {
+public record PageCursor<T>(CursorRequest nextCursorRequest, List<T> posts) {
 
-    public static PageCursor<?> from(CursorRequest nextCursorRequest, List<?> body) {
-        return new PageCursor<>(nextCursorRequest, body);
+    public static PageCursor<PostDetailResponse> from(CursorRequest nextCursorRequest, List<PostDetailResponse> posts) {
+        return new PageCursor<>(nextCursorRequest, posts);
     }
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -15,6 +15,7 @@ spring.sql.init.mode=always
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.default_batch_fetch_size=1000
 spring.jpa.open-in-view=true
 spring.jpa.hibernate.ddl-auto=create-drop
 

--- a/src/test/java/com/numble/instagram/application/usecase/post/GetFeedPostsUsecaseTest.java
+++ b/src/test/java/com/numble/instagram/application/usecase/post/GetFeedPostsUsecaseTest.java
@@ -50,7 +50,7 @@ class GetFeedPostsUsecaseTest {
 
         when(userReadService.getUser(user.getId())).thenReturn(user);
         when(feedReadService.getFeeds(user.getId(), cursorRequest)).thenReturn(feeds);
-        when(postLikeReadService.getPostLike(user, List.of(feeds.get(0).getPost(), feeds.get(1).getPost()))).thenReturn(List.of(true, false));
+        when(postLikeReadService.getPostLikes(user, List.of(feeds.get(0).getPost(), feeds.get(1).getPost()))).thenReturn(List.of(true, false));
 
         PageCursor<?> result = getFeedPostsUsecase.execute(user.getId(), cursorRequest);
 

--- a/src/test/java/com/numble/instagram/application/usecase/post/GetFeedPostsUsecaseTest.java
+++ b/src/test/java/com/numble/instagram/application/usecase/post/GetFeedPostsUsecaseTest.java
@@ -1,0 +1,66 @@
+package com.numble.instagram.application.usecase.post;
+
+import com.numble.instagram.domain.post.entity.Feed;
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.post.service.FeedReadService;
+import com.numble.instagram.domain.post.service.PostLikeReadService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.response.post.PostDetailResponse;
+import com.numble.instagram.support.paging.CursorRequest;
+import com.numble.instagram.support.paging.PageCursor;
+import com.numble.instagram.util.fixture.post.FeedFixture;
+import com.numble.instagram.util.fixture.post.PostFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetFeedPostsUsecaseTest {
+
+    @InjectMocks
+    private GetFeedPostsUsecase getFeedPostsUsecase;
+
+    @Mock
+    private UserReadService userReadService;
+
+    @Mock
+    private FeedReadService feedReadService;
+
+    @Mock
+    private PostLikeReadService postLikeReadService;
+
+    @Test
+    @DisplayName("피드는 조회되어야한다.")
+    void execute() {
+        User user = UserFixture.create("user");
+        Post post1 = PostFixture.create( "post-content1");
+        Post post2 = PostFixture.create("post-content2");
+        List<Feed> feeds = FeedFixture.createFeedsWithIds(user, List.of(post1, post2), List.of(1L, 2L));
+        CursorRequest cursorRequest = new CursorRequest(null, 10);
+
+        when(userReadService.getUser(user.getId())).thenReturn(user);
+        when(feedReadService.getFeeds(user.getId(), cursorRequest)).thenReturn(feeds);
+        when(postLikeReadService.getPostLike(user, List.of(feeds.get(0).getPost(), feeds.get(1).getPost()))).thenReturn(List.of(true, false));
+
+        PageCursor<?> result = getFeedPostsUsecase.execute(user.getId(), cursorRequest);
+
+        assertThat(result.body()).hasSize(2);
+        assertThat(result.nextCursorRequest().key()).isEqualTo(1L);
+        PostDetailResponse postDetailResponse1 = (PostDetailResponse) result.body().get(0);
+        PostDetailResponse postDetailResponse2 = (PostDetailResponse) result.body().get(1);
+        assertThat(postDetailResponse1.postId()).isEqualTo(feeds.get(0).getPost().getId());
+        assertThat(postDetailResponse1.isPostLiked()).isTrue();
+        assertThat(postDetailResponse2.postId()).isEqualTo(feeds.get(1).getPost().getId());
+        assertThat(postDetailResponse2.isPostLiked()).isFalse();
+    }
+}

--- a/src/test/java/com/numble/instagram/application/usecase/post/GetFeedPostsUsecaseTest.java
+++ b/src/test/java/com/numble/instagram/application/usecase/post/GetFeedPostsUsecaseTest.java
@@ -54,10 +54,10 @@ class GetFeedPostsUsecaseTest {
 
         PageCursor<?> result = getFeedPostsUsecase.execute(user.getId(), cursorRequest);
 
-        assertThat(result.body()).hasSize(2);
+        assertThat(result.posts()).hasSize(2);
         assertThat(result.nextCursorRequest().key()).isEqualTo(1L);
-        PostDetailResponse postDetailResponse1 = (PostDetailResponse) result.body().get(0);
-        PostDetailResponse postDetailResponse2 = (PostDetailResponse) result.body().get(1);
+        PostDetailResponse postDetailResponse1 = (PostDetailResponse) result.posts().get(0);
+        PostDetailResponse postDetailResponse2 = (PostDetailResponse) result.posts().get(1);
         assertThat(postDetailResponse1.postId()).isEqualTo(feeds.get(0).getPost().getId());
         assertThat(postDetailResponse1.isPostLiked()).isTrue();
         assertThat(postDetailResponse2.postId()).isEqualTo(feeds.get(1).getPost().getId());

--- a/src/test/java/com/numble/instagram/concurrency/PostLikeConcurrencyTest.java
+++ b/src/test/java/com/numble/instagram/concurrency/PostLikeConcurrencyTest.java
@@ -6,6 +6,7 @@ import com.numble.instagram.domain.post.repository.PostRepository;
 import com.numble.instagram.domain.user.entity.User;
 import com.numble.instagram.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,8 +22,8 @@ class PostLikeConcurrencyTest {
     PostRepository postRepository;
     @Autowired
     UserRepository userRepository;
-    @Autowired
-    EntityManager em;
+    @PersistenceContext
+    private EntityManager em;
     @Autowired
     CreatePostLikeUsecase createPostLikeUsecase;
 

--- a/src/test/java/com/numble/instagram/domain/post/service/CommentWriteServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/post/service/CommentWriteServiceTest.java
@@ -80,7 +80,7 @@ class CommentWriteServiceTest {
     public void testEditNonExistingComment() {
         User user = UserFixture.create("user");
         Post post = PostFixture.create("post-content");
-        Comment comment = CommentFixture.create(user, post, "old comment content");
+        Comment comment = CommentFixture.create(user, post);
         when(commentRepository.findById(any(Long.class))).thenReturn(Optional.empty());
         assertThrows(CommentNotFoundException.class, () ->
             commentWriteService.edit(user, comment.getId(), "test_comment_content")

--- a/src/test/java/com/numble/instagram/domain/post/service/FeedReadServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/post/service/FeedReadServiceTest.java
@@ -74,8 +74,5 @@ class FeedReadServiceTest {
         List<Feed> result = feedReadService.getFeeds(follower.getId(), cursorRequest);
 
         assertEquals(10, result.size());
-        for (Feed feed : result) {
-            System.out.println("feed.getPost().getContent() = " + feed.getPost().getContent());
-        }
     }
 }

--- a/src/test/java/com/numble/instagram/domain/post/service/FeedReadServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/post/service/FeedReadServiceTest.java
@@ -1,0 +1,81 @@
+package com.numble.instagram.domain.post.service;
+
+import com.numble.instagram.domain.post.entity.Comment;
+import com.numble.instagram.domain.post.entity.Feed;
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.post.entity.Reply;
+import com.numble.instagram.domain.post.repository.CommentRepository;
+import com.numble.instagram.domain.post.repository.FeedRepository;
+import com.numble.instagram.domain.post.repository.PostRepository;
+import com.numble.instagram.domain.post.repository.ReplyRepository;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.repository.UserRepository;
+import com.numble.instagram.support.paging.CursorRequest;
+import com.numble.instagram.util.fixture.post.CommentFixture;
+import com.numble.instagram.util.fixture.post.FeedFixture;
+import com.numble.instagram.util.fixture.post.PostFixture;
+import com.numble.instagram.util.fixture.post.ReplyFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+class FeedReadServiceTest {
+
+    @Autowired
+    private FeedRepository feedRepository;
+    @Autowired
+    private FeedReadService feedReadService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PostRepository postRepository;
+    @Autowired
+    private CommentRepository commentRepository;
+    @Autowired
+    private ReplyRepository replyRepository;
+    @PersistenceContext
+    private EntityManager em;
+
+    @Test
+    @DisplayName("feed는 조회되어야 한다.")
+    @Transactional
+    void getFeeds() {
+        User user = UserFixture.create("user");
+        userRepository.save(user);
+
+        List<Post> posts = PostFixture.createPosts(user);
+        postRepository.saveAll(posts);
+
+        User follower = UserFixture.create("follower");
+        userRepository.save(follower);
+        List<Feed> feeds = FeedFixture.createFeeds(follower, posts);
+        feedRepository.saveAll(feeds);
+
+        List<Comment> comments = CommentFixture.createComments(user, posts);
+        commentRepository.saveAll(comments);
+
+        List<Reply> replies = ReplyFixture.createReplies(user, comments);
+        replyRepository.saveAll(replies);
+
+        em.clear();
+        em.flush();
+
+        CursorRequest cursorRequest = new CursorRequest(null, 10);
+        List<Feed> result = feedReadService.getFeeds(follower.getId(), cursorRequest);
+
+        assertEquals(10, result.size());
+        for (Feed feed : result) {
+            System.out.println("feed.getPost().getContent() = " + feed.getPost().getContent());
+        }
+    }
+}

--- a/src/test/java/com/numble/instagram/domain/post/service/PostLikeReadServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/post/service/PostLikeReadServiceTest.java
@@ -1,0 +1,44 @@
+package com.numble.instagram.domain.post.service;
+
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.post.repository.PostLikeRepository;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.util.fixture.post.PostFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PostLikeReadServiceTest {
+
+    @InjectMocks
+    private PostLikeReadService postLikeReadService;
+
+    @Mock
+    private PostLikeRepository postLikeRepository;
+
+    @Test
+    void getPostLike() {
+        User user = UserFixture.create("user");
+        Post post1 = PostFixture.create("post-content1");
+        Post post2 = PostFixture.create("post-content2");
+        List<Post> posts = List.of(post1, post2);
+
+        when(postLikeRepository.findAllByUserAndPosts(eq(user), eq(posts))).thenReturn(Arrays.asList(true, false));
+
+        List<Boolean> isPostLike = postLikeReadService.getPostLikes(user, posts);
+
+        assertThat(isPostLike.get(0)).isFalse();
+        assertThat(isPostLike.get(1)).isTrue();
+    }
+}

--- a/src/test/java/com/numble/instagram/domain/post/service/ReplyWriteServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/post/service/ReplyWriteServiceTest.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,9 +68,9 @@ class ReplyWriteServiceTest {
     void wrongWriter() {
         User user = UserFixture.create("user");
         Comment comment = CommentFixture.create("comment-content");
-        Reply reply = ReplyFixture.create(user, comment, "old reply content");
+        Reply reply = ReplyFixture.create(user, comment);
         User wrongWriter = UserFixture.create("wrongWriter");
-        when(replyRepository.findById(comment.getId())).thenReturn(Optional.of(reply));
+        when(replyRepository.findById(eq(comment.getId()))).thenReturn(Optional.of(reply));
 
         assertThrows(
                 NotReplyWriterException.class,
@@ -83,7 +84,7 @@ class ReplyWriteServiceTest {
         User user = UserFixture.create("user");
         Comment comment = CommentFixture.create("comment-content");
         Reply reply = ReplyFixture.create(user, comment, "old reply content");
-        when(replyRepository.findById(any(Long.class))).thenReturn(Optional.empty());
+        when(replyRepository.findById(eq(user.getId()))).thenReturn(Optional.empty());
         assertThrows(ReplyNotFoundException.class, () ->
                 replyWriteService.edit(user, reply.getId(), "test_comment_content")
         );

--- a/src/test/java/com/numble/instagram/presentation/post/FeedControllerDocsTest.java
+++ b/src/test/java/com/numble/instagram/presentation/post/FeedControllerDocsTest.java
@@ -1,0 +1,159 @@
+package com.numble.instagram.presentation.post;
+
+import com.numble.instagram.application.auth.token.TokenProvider;
+import com.numble.instagram.application.usecase.post.GetFeedPostsUsecase;
+import com.numble.instagram.dto.response.post.CommentDetailResponse;
+import com.numble.instagram.dto.response.post.PostDetailResponse;
+import com.numble.instagram.dto.response.post.ReplyDetailResponse;
+import com.numble.instagram.support.paging.CursorRequest;
+import com.numble.instagram.support.paging.PageCursor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.LongStream;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
+class FeedControllerDocsTest {
+
+    private MockMvc mockMvc;
+    @MockBean
+    private TokenProvider tokenProvider;
+    @MockBean
+    private GetFeedPostsUsecase getFeedPostsUsecase;
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+    private static final String DOCUMENT_IDENTIFIER = "feed/{method-name}/";
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint(), modifyHeaders().remove("Vary")))
+                .build();
+    }
+
+    @Test
+    @DisplayName("피드를 조회한다.")
+    void getFeeds() throws Exception {
+        String authorizationHeader = "Bearer access-token";
+        Long userId = 1L;
+        given(tokenProvider.isValidToken(authorizationHeader)).willReturn(true);
+        given(tokenProvider.getUserId(authorizationHeader)).willReturn(userId);
+
+        CursorRequest cursorRequest = new CursorRequest(10L, 5);
+
+        ReplyDetailResponse replyResponse = new ReplyDetailResponse(
+                1L,
+                "reply-content",
+                LocalDateTime.now(),
+                1L,
+                "replyWriter",
+                "https://profileImage.jpg"
+        );
+
+        List<CommentDetailResponse> comments = new ArrayList<>(LongStream.range(1L, 4L).mapToObj(i ->
+                new CommentDetailResponse(i,
+                        "comment-content" + i,
+                        LocalDateTime.now(),
+                        i,
+                        "commentWriter_" + i,
+                        "https://profileImage.png",
+                        List.of(replyResponse))).toList());
+        Collections.reverse(comments);
+
+        List<PostDetailResponse> postDetailResponses = new ArrayList<>(LongStream.range(1L, 6L).mapToObj(i ->
+                new PostDetailResponse(i,
+                        "post-content" + i,
+                        "https://postImage" + i + ".png",
+                        0L,
+                        LocalDateTime.now().minusDays(i),
+                        LocalDate.now().minusDays(i),
+                        userId,
+                        "post-writer",
+                        "https://profileImage.png",
+                        true,
+                        comments)).toList());
+        Collections.reverse(postDetailResponses);
+
+        PageCursor<PostDetailResponse> pageCursor = new PageCursor<>(new CursorRequest(1L, 5), postDetailResponses);
+
+        given(getFeedPostsUsecase.execute(eq(userId), eq(cursorRequest))).willReturn(pageCursor);
+
+        mockMvc.perform(get("/api/feed")
+                        .param("key", String.valueOf(cursorRequest.key()))
+                        .param("size", String.valueOf(cursorRequest.size()))
+                        .header(HttpHeaders.AUTHORIZATION, authorizationHeader))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document(DOCUMENT_IDENTIFIER,
+                        queryParameters(
+                                parameterWithName("key").description("가져 올 커서의 key"),
+                                parameterWithName("size").description("가져올 포스트의 size")
+                        ),
+                        responseFields(
+                                fieldWithPath("nextCursorRequest").description("다음 커서 정보"),
+                                fieldWithPath("nextCursorRequest.key").description("다음 커서 key"),
+                                fieldWithPath("nextCursorRequest.size").description("페이지 size"),
+                                fieldWithPath("posts").description("게시글 정보"),
+                                fieldWithPath("posts[].postId").description("게시글 id"),
+                                fieldWithPath("posts[].content").description("게시글 내용"),
+                                fieldWithPath("posts[].postImageUrl").description("게시글 이미지 URL"),
+                                fieldWithPath("posts[].likeCount").description("게시글 좋아요 수"),
+                                fieldWithPath("posts[].createdAt").description("게시 날짜 시간"),
+                                fieldWithPath("posts[].createdDate").description("게시 날짜"),
+                                fieldWithPath("posts[].userId").description("게시글 작성자"),
+                                fieldWithPath("posts[].nickname").description("게시글 작성자 닉네임"),
+                                fieldWithPath("posts[].profileImageUrl").description("게시글 작성자 profile URL"),
+                                fieldWithPath("posts[].isPostLiked").description("작성자의 게시글 좋아요 여부"),
+                                fieldWithPath("posts[].comments").description("게시글의 댓글 정보"),
+                                fieldWithPath("posts[].comments[].commentId").description("댓글 id"),
+                                fieldWithPath("posts[].comments[].content").description("댓글 내용"),
+                                fieldWithPath("posts[].comments[].createdAt").description("댓글 단 날짜 시간"),
+                                fieldWithPath("posts[].comments[].userId").description("댓글 작성자 id"),
+                                fieldWithPath("posts[].comments[].nickname").description("댓글 작성자 닉네임"),
+                                fieldWithPath("posts[].comments[].profileImageUrl").description("댓글 작성자 profile URL"),
+                                fieldWithPath("posts[].comments[].replies").description("댓글의 답글 정보"),
+                                fieldWithPath("posts[].comments[].replies[].replyId").description("답글 id"),
+                                fieldWithPath("posts[].comments[].replies[].content").description("답글 내용"),
+                                fieldWithPath("posts[].comments[].replies[].createdAt").description("답글 단 날짜시간"),
+                                fieldWithPath("posts[].comments[].replies[].userId").description("답글 작성자 id"),
+                                fieldWithPath("posts[].comments[].replies[].nickname").description("답글 작성자 닉네임"),
+                                fieldWithPath("posts[].comments[].replies[].profileImageUrl").description("답글 작성자 profile URL")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/numble/instagram/util/fixture/post/CommentFixture.java
+++ b/src/test/java/com/numble/instagram/util/fixture/post/CommentFixture.java
@@ -7,12 +7,17 @@ import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.jeasy.random.FieldPredicates.*;
 
 public class CommentFixture {
 
     public static Comment create(User user, Post post, String content) {
+        var idPredicate = named("id")
+                .and(ofType(Long.class))
+                .and(inClass(Comment.class));
+
         var contentPredicate = named("content")
                 .and(ofType(String.class))
                 .and(inClass(Comment.class));
@@ -27,6 +32,24 @@ public class CommentFixture {
 
         var param = new EasyRandomParameters()
                 .randomize(contentPredicate, () -> content)
+                .randomize(postPredicate, () -> post)
+                .randomize(commentWriterUserPredicate, () -> user)
+                .excludeField(idPredicate)
+                .dateRange(LocalDate.now(), LocalDate.now());
+
+        return new EasyRandom(param).nextObject(Comment.class);
+    }
+
+    public static Comment create(User user, Post post) {
+        var commentWriterUserPredicate = named("commentWriteUser")
+                .and(ofType(User.class))
+                .and(inClass(Comment.class));
+
+        var postPredicate = named("post")
+                .and(ofType(Post.class))
+                .and(inClass(Comment.class));
+
+        var param = new EasyRandomParameters()
                 .randomize(postPredicate, () -> post)
                 .randomize(commentWriterUserPredicate, () -> user)
                 .dateRange(LocalDate.now(), LocalDate.now());
@@ -44,5 +67,11 @@ public class CommentFixture {
                 .dateRange(LocalDate.now(), LocalDate.now());
 
         return new EasyRandom(param).nextObject(Comment.class);
+    }
+
+    public static List<Comment> createComments(User user, List<Post> posts) {
+        return posts.stream()
+                .map(post -> create(user, post, "comment-content"))
+                .toList();
     }
 }

--- a/src/test/java/com/numble/instagram/util/fixture/post/FeedFixture.java
+++ b/src/test/java/com/numble/instagram/util/fixture/post/FeedFixture.java
@@ -3,8 +3,14 @@ package com.numble.instagram.util.fixture.post;
 import com.numble.instagram.domain.post.entity.Feed;
 import com.numble.instagram.domain.post.entity.Post;
 import com.numble.instagram.domain.user.entity.User;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
 
+import java.time.LocalDate;
+import java.util.Iterator;
 import java.util.List;
+
+import static org.jeasy.random.FieldPredicates.*;
 
 public class FeedFixture {
 
@@ -12,9 +18,38 @@ public class FeedFixture {
         return new Feed(user, post, post.getCreatedAt());
     }
 
+    public static Feed createWithId(Long id, User user, Post post) {
+        var idPredicate = named("id")
+                .and(ofType(Long.class))
+                .and(inClass(Feed.class));
+
+        var postPredicate = named("post")
+                .and(ofType(Post.class))
+                .and(inClass(Feed.class));
+
+        var userPredicate = named("user")
+                .and(ofType(User.class))
+                .and(inClass(Feed.class));
+
+        var param = new EasyRandomParameters()
+                .randomize(idPredicate, () -> id)
+                .randomize(userPredicate, () -> user)
+                .randomize(postPredicate, () -> post)
+                .dateRange(LocalDate.now(), LocalDate.now());
+
+        return new EasyRandom(param).nextObject(Feed.class);
+    }
+
     public static List<Feed> createFeeds(User user, List<Post> posts) {
         return posts.stream()
                 .map(post -> create(user, post))
+                .toList();
+    }
+
+    public static List<Feed> createFeedsWithIds(User user, List<Post> posts, List<Long> ids) {
+        Iterator<Long> idIterator = ids.stream().iterator();
+        return posts.stream()
+                .map(post -> createWithId(idIterator.next() , user, post))
                 .toList();
     }
 }

--- a/src/test/java/com/numble/instagram/util/fixture/post/FeedFixture.java
+++ b/src/test/java/com/numble/instagram/util/fixture/post/FeedFixture.java
@@ -1,0 +1,20 @@
+package com.numble.instagram.util.fixture.post;
+
+import com.numble.instagram.domain.post.entity.Feed;
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.user.entity.User;
+
+import java.util.List;
+
+public class FeedFixture {
+
+    public static Feed create(User user, Post post) {
+        return new Feed(user, post, post.getCreatedAt());
+    }
+
+    public static List<Feed> createFeeds(User user, List<Post> posts) {
+        return posts.stream()
+                .map(post -> create(user, post))
+                .toList();
+    }
+}

--- a/src/test/java/com/numble/instagram/util/fixture/post/PostFixture.java
+++ b/src/test/java/com/numble/instagram/util/fixture/post/PostFixture.java
@@ -6,6 +6,8 @@ import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.jeasy.random.FieldPredicates.*;
 
@@ -44,14 +46,25 @@ public class PostFixture {
     }
 
     public static Post create(String content) {
+        var idPredicate = named("id")
+                .and(ofType(Long.class))
+                .and(inClass(Post.class));
+
         var contentPredicate = named("content")
                 .and(ofType(String.class))
                 .and(inClass(Post.class));
 
         var param = new EasyRandomParameters()
                 .randomize(contentPredicate, () -> content)
+                .excludeField(idPredicate)
                 .dateRange(LocalDate.now(), LocalDate.now());
 
         return new EasyRandom(param).nextObject(Post.class);
+    }
+
+    public static List<Post> createPosts(User user) {
+        return IntStream.range(0, 20)
+                .mapToObj(i -> create("imageUrl " + i, "post-content " + i, user))
+                .toList();
     }
 }

--- a/src/test/java/com/numble/instagram/util/fixture/post/ReplyFixture.java
+++ b/src/test/java/com/numble/instagram/util/fixture/post/ReplyFixture.java
@@ -7,12 +7,17 @@ import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.jeasy.random.FieldPredicates.*;
 
 public class ReplyFixture {
 
     public static Reply create(User user, Comment comment, String content) {
+        var idPredicate = named("id")
+                .and(ofType(Long.class))
+                .and(inClass(Reply.class));
+
         var contentPredicate = named("content")
                 .and(ofType(String.class))
                 .and(inClass(Reply.class));
@@ -29,8 +34,33 @@ public class ReplyFixture {
                 .randomize(contentPredicate, () -> content)
                 .randomize(commentPredicate, () -> comment)
                 .randomize(replyWriteUserPredicate, () -> user)
+                .excludeField(idPredicate)
                 .dateRange(LocalDate.now(), LocalDate.now());
 
         return new EasyRandom(param).nextObject(Reply.class);
+    }
+
+    public static Reply create(User user, Comment comment) {
+
+        var replyWriteUserPredicate = named("replyWriteUser")
+                .and(ofType(User.class))
+                .and(inClass(Reply.class));
+
+        var commentPredicate = named("comment")
+                .and(ofType(Comment.class))
+                .and(inClass(Reply.class));
+
+        var param = new EasyRandomParameters()
+                .randomize(commentPredicate, () -> comment)
+                .randomize(replyWriteUserPredicate, () -> user)
+                .dateRange(LocalDate.now(), LocalDate.now());
+
+        return new EasyRandom(param).nextObject(Reply.class);
+    }
+
+    public static List<Reply> createReplies(User user, List<Comment> comments) {
+        return comments.stream()
+                .map(comment -> create(user, comment, "reply-content"))
+                .toList();
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,3 +2,9 @@
 jwt.token.secret=TestLJNO9KUPS2RN+HVVUYT9LUDMUAGIMUEMKVXR4DH5I=
 jwt.token.valid-time-in-milliseconds=7200000
 token.refresh.valid-time-in-days=7
+
+spring.jpa.properties.hibernate.default_batch_fetch_size=1000
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE


### PR DESCRIPTION
## 작업 주제

- 피드 조회 기능 

## optional 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 피드 조회시 페이징 방식은 cursor 방식으로 진행했습니다. 
- Post 저장 시 Feed 테이블에 모든 팔로워의 Id 와 Post의 아이디를 저장해주었기 때문에 사용자를 기준으로 팔로잉한 사람들의 글을 조회합니다.
- Feed, Post, Comment, Reply, User, PostLike 테이블들을 모두 조회하여 데이터를 가져오기 위해 n + 1 문제, 쿼리문을 최적화 시키기 위해 노력했습니다. 

## optional 화면 스크린샷

- 결론적으로 1번의 요청시에 5번의 쿼리문이 나가게 됩니다. 
```
// 1. 사용자 조회 쿼리

Hibernate: 
    select
        u1_0.id,
        u1_0.joined_at,
        u1_0.nickname,
        u1_0.password,
        u1_0.profile_image_url 
    from
        users u1_0 
    where
        u1_0.id=?

// 2. Feed 테이블 join fetch Post, User 쿼리

Hibernate: 
    select
        f1_0.id,
        f1_0.created_at,
        p1_0.id,
        p1_0.content,
        p1_0.created_at,
        p1_0.created_date,
        p1_0.like_count,
        p1_0.post_image_url,
        p1_0.version,
        w1_0.id,
        w1_0.joined_at,
        w1_0.nickname,
        w1_0.password,
        w1_0.profile_image_url,
        f1_0.user_id 
    from
        feed f1_0 
    left join
        post p1_0 
            on p1_0.id=f1_0.post_id 
    left join
        users w1_0 
            on w1_0.id=p1_0.user_id 
    where
        f1_0.user_id=? 
    order by
        f1_0.created_at desc limit ?

// 3. PostLike 여부 조회 쿼리(사용자가 해당 Post를 좋아요 했는가)

Hibernate: 
    select
        case 
            when (select
                count(p2_0.id) 
            from
                post_like p2_0 
            where
                p2_0.post_id=p1_0.id 
                and p2_0.user_id=?)>0 then 1 
            else 0 
        end 
    from
        post p1_0 
    where
        p1_0.id in(?,?,?,?,?,?,?,?,?)

// 4. Comment 테이블 쿼리 OneToMany

Hibernate: 
    select
        c1_0.post_id,
        c1_0.id,
        c1_0.user_id,
        c1_0.content,
        c1_0.created_at 
    from
        comment c1_0 
    where
        c1_0.post_id in(?,?,?,?,?,?,?,?,?)

// 5. Reply 테이블 쿼리 OneToMany

Hibernate: 
    select
        r1_0.comment_id,
        r1_0.id,
        r1_0.content,
        r1_0.created_at,
        r1_0.user_id 
    from
        reply r1_0 
    where
        r1_0.comment_id in(?,?,?,?,?,?,?,?,?)
```

- 피드 조회 기능의 Usecase
```java
@Service
@RequiredArgsConstructor
public class GetFeedPostsUsecase {

    private final UserReadService userReadService;
    private final FeedReadService feedReadService;
    private final PostLikeReadService postLikeReadService;

    public PageCursor<PostDetailResponse> execute(Long userId, CursorRequest cursorRequest) {
        User user = userReadService.getUser(userId);
        List<Feed> feeds = feedReadService.getFeeds(user.getId(), cursorRequest);

        Long nextKey = feeds.stream()
                .mapToLong(Feed::getId)
                .min()
                .orElse(CursorRequest.NONE_KEY);

        List<Post> posts = feeds.stream()
                .map(Feed::getPost)
                .toList();

        Iterator<Boolean> isPostLikedIterator = postLikeReadService.getPostLikes(user, posts).iterator();

        List<PostDetailResponse> postDetailResponses = posts.stream()
                .map(post -> PostDetailResponse.from(post, isPostLikedIterator.next()))
                .toList();

        return PageCursor.from(cursorRequest.next(nextKey), postDetailResponses);
    }
}
```

## optional 관련 Docs

- [향로님 블로그](https://jojoldu.tistory.com/457) : OneToMany 상황에서 join fetch가 두 번 연속 안되는 현상에서 도움 받은 블로그 (default_batch_fetch_size 관련) 
- [자바봄님 블로그](https://javabom.tistory.com/104) : OneToMany를 join fetch 하는데 메모리에서 페이징이 된다는 경고에서 도움 받은 블로그 -> 이로 인해 쿼리문이 1개 더 늘어났지만 성능은 좋아졌을거라 기대함.

## optional 추가 코멘트

- Jpa로 많은 entity의 데이터를 최적화해서 가져오는게 쉽지 않네요.
- 더 좋은 방법, 더 최적화 시킬 수 있는 방법이 있으면 리뷰 부탁드립니다.

## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [x] base, compare branch가 적절하게 선택되었나요?
- [x] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)