### PR TITLE
글 삭제, 댓글 삭제, 답글 삭제 기능 

### DIFF
--- a/src/docs/asciidoc/post.adoc
+++ b/src/docs/asciidoc/post.adoc
@@ -134,3 +134,39 @@ include::{snippets}/post/dislike-post/path-parameters.adoc[]
 ==== Response
 include::{snippets}/post/dislike-post/http-response.adoc[]
 include::{snippets}/post/dislike-post/response-fields.adoc[]
+
+'''
+
+=== 글 삭제
+==== Request
+include::{snippets}/post/delete-post/http-request.adoc[]
+- path parameter
+
+include::{snippets}/post/delete-post/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/post/delete-post/http-response.adoc[]
+
+'''
+
+=== 댓글 삭제
+==== Request
+include::{snippets}/post/delete-comment/http-request.adoc[]
+- path parameter
+
+include::{snippets}/post/delete-comment/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/post/delete-comment/http-response.adoc[]
+
+'''
+
+=== 답글 삭제
+==== Request
+include::{snippets}/post/delete-reply/http-request.adoc[]
+- path parameter
+
+include::{snippets}/post/delete-reply/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/post/delete-reply/http-response.adoc[]

--- a/src/main/java/com/numble/instagram/application/usecase/post/DestroyCommentUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/post/DestroyCommentUsecase.java
@@ -1,0 +1,20 @@
+package com.numble.instagram.application.usecase.post;
+
+import com.numble.instagram.domain.post.service.CommentWriteService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DestroyCommentUsecase {
+
+    private final UserReadService userReadService;
+    private final CommentWriteService commentWriteService;
+
+    public void execute(Long userId, Long commentId) {
+        User user = userReadService.getUser(userId);
+        commentWriteService.deleteComment(user, commentId);
+    }
+}

--- a/src/main/java/com/numble/instagram/application/usecase/post/DestroyPostUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/post/DestroyPostUsecase.java
@@ -1,0 +1,32 @@
+package com.numble.instagram.application.usecase.post;
+
+import com.numble.instagram.domain.post.entity.Post;
+import com.numble.instagram.domain.post.service.FeedWriteService;
+import com.numble.instagram.domain.post.service.PostLikeWriteService;
+import com.numble.instagram.domain.post.service.PostReadService;
+import com.numble.instagram.domain.post.service.PostWriteService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DestroyPostUsecase {
+
+    private final UserReadService userReadService;
+    private final PostReadService postReadService;
+    private final PostLikeWriteService postLikeWriteService;
+    private final FeedWriteService feedWriteService;
+    private final PostWriteService postWriteService;
+
+    public void execute(Long userId, Long postId) {
+        User user = userReadService.getUser(userId);
+        Post post = postReadService.getPost(postId);
+        if (post.isWriter(user)) {
+            postLikeWriteService.deletePostLike(post);
+            feedWriteService.deleteFeed(post);
+        }
+        postWriteService.deletePost(user, post);
+    }
+}

--- a/src/main/java/com/numble/instagram/application/usecase/post/DestroyReplyUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/post/DestroyReplyUsecase.java
@@ -1,0 +1,21 @@
+package com.numble.instagram.application.usecase.post;
+
+import com.numble.instagram.domain.post.service.ReplyWriteService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DestroyReplyUsecase {
+
+    private final UserReadService userReadService;
+    private final ReplyWriteService replyWriteService;
+
+    public void execute(Long userId, Long replyId) {
+        User user = userReadService.getUser(userId);
+        replyWriteService.deleteReply(user, replyId);
+
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/post/entity/Comment.java
+++ b/src/main/java/com/numble/instagram/domain/post/entity/Comment.java
@@ -37,7 +37,7 @@ public class Comment {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "comment", fetch = LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "comment", fetch = LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Reply> replies = new ArrayList<>();
 
     @PrePersist

--- a/src/main/java/com/numble/instagram/domain/post/entity/Post.java
+++ b/src/main/java/com/numble/instagram/domain/post/entity/Post.java
@@ -41,7 +41,7 @@ public class Post {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "post", fetch = LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", fetch = LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
     @Version

--- a/src/main/java/com/numble/instagram/domain/post/repository/FeedRepository.java
+++ b/src/main/java/com/numble/instagram/domain/post/repository/FeedRepository.java
@@ -1,7 +1,12 @@
 package com.numble.instagram.domain.post.repository;
 
 import com.numble.instagram.domain.post.entity.Feed;
+import com.numble.instagram.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositoryCustom {
+
+    List<Feed> findAllByPost(Post post);
 }

--- a/src/main/java/com/numble/instagram/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/numble/instagram/domain/post/repository/PostLikeRepository.java
@@ -29,4 +29,6 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
             where p in :posts
     """)
     List<Boolean> findAllByUserAndPosts(@Param("user") User user, @Param("posts") List<Post> posts);
+
+    List<PostLike> findAllByPost(Post post);
 }

--- a/src/main/java/com/numble/instagram/domain/post/service/CommentWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/CommentWriteService.java
@@ -28,16 +28,26 @@ public class CommentWriteService {
     }
 
     public Comment edit(User user, Long commentId, String content) {
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(CommentNotFoundException::new);
+        Comment comment = getComment(commentId);
         checkCommentWriter(user, comment);
         comment.updateContent(content);
         return comment;
+    }
+
+    public void deleteComment(User user, Long commentId) {
+        Comment comment = getComment(commentId);
+        checkCommentWriter(user, comment);
+        commentRepository.delete(comment);
     }
 
     private static void checkCommentWriter(User user, Comment comment) {
         if (!comment.isCommentWriteUser(user)) {
             throw new NotCommentWriterException();
         }
+    }
+
+    private Comment getComment(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(CommentNotFoundException::new);
     }
 }

--- a/src/main/java/com/numble/instagram/domain/post/service/FeedWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/FeedWriteService.java
@@ -26,6 +26,11 @@ public class FeedWriteService {
         feedRepository.saveAll(feeds);
     }
 
+    public void deleteFeed(Post post) {
+        List<Feed> feeds = feedRepository.findAllByPost(post);
+        feedRepository.deleteAll(feeds);
+    }
+
     private Feed toFeed(Post newPost, User follower) {
         return Feed.builder()
                 .user(follower)

--- a/src/main/java/com/numble/instagram/domain/post/service/PostLikeWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/PostLikeWriteService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -27,6 +29,11 @@ public class PostLikeWriteService {
         PostLike postLike = postLikeRepository.findByUserAndPost(user, post)
                 .orElseThrow(NotLikedPostException::new);
         postLikeRepository.delete(postLike);
+    }
+
+    public void deletePostLike(Post post) {
+        List<PostLike> postLikes = postLikeRepository.findAllByPost(post);
+        postLikeRepository.deleteAll(postLikes);
     }
 
     private void checkLiked(User user, Post post) {

--- a/src/main/java/com/numble/instagram/domain/post/service/PostWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/PostWriteService.java
@@ -46,6 +46,11 @@ public class PostWriteService {
         post.decrementLikeCount();
     }
 
+    public void deletePost(User user, Post post) {
+        checkWriter(user, post);
+        postRepository.delete(post);
+    }
+
     private static void checkWriter(User user, Post post) {
         if (!post.isWriter(user)) {
             throw new NotPostWriterException();

--- a/src/main/java/com/numble/instagram/domain/post/service/ReplyWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/post/service/ReplyWriteService.java
@@ -27,11 +27,21 @@ public class ReplyWriteService {
     }
 
     public Reply edit(User user, Long replyId, String content) {
-        Reply reply = replyRepository.findById(replyId)
-                .orElseThrow(ReplyNotFoundException::new);
+        Reply reply = getReply(replyId);
         checkReplyWriter(user, reply);
         reply.updateContent(content);
         return reply;
+    }
+
+    public void deleteReply(User user, Long replyId) {
+        Reply reply = getReply(replyId);
+        checkReplyWriter(user, reply);
+        replyRepository.delete(reply);
+    }
+
+    private Reply getReply(Long replyId) {
+        return replyRepository.findById(replyId)
+                .orElseThrow(ReplyNotFoundException::new);
     }
 
     private static void checkReplyWriter(User user, Reply reply) {

--- a/src/main/java/com/numble/instagram/presentation/post/PostController.java
+++ b/src/main/java/com/numble/instagram/presentation/post/PostController.java
@@ -12,6 +12,7 @@ import com.numble.instagram.dto.response.post.ReplyResponse;
 import com.numble.instagram.presentation.auth.AuthenticatedUser;
 import com.numble.instagram.presentation.auth.Login;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,6 +29,9 @@ public class PostController {
     private final EditReplyUsecase editReplyUsecase;
     private final CreatePostLikeUsecase createPostLikeUsecase;
     private final DestroyPostLikeUsecase destroyPostLikeUsecase;
+    private final DestroyReplyUsecase destroyReplyUsecase;
+    private final DestroyCommentUsecase destroyCommentUsecase;
+    private final DestroyPostUsecase destroyPostUsecase;
 
     @Login
     @PostMapping
@@ -88,5 +92,29 @@ public class PostController {
     public PostLikeResponse dislikePost(@AuthenticatedUser Long userId,
                                         @PathVariable Long postId) {
         return destroyPostLikeUsecase.execute(userId, postId);
+    }
+
+    @Login
+    @DeleteMapping("/reply/{replyId}")
+    public ResponseEntity<Void> deleteReply(@AuthenticatedUser Long userId,
+                                            @PathVariable Long replyId) {
+        destroyReplyUsecase.execute(userId, replyId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Login
+    @DeleteMapping("/comment/{commentId}")
+    public ResponseEntity<Void> deleteComment(@AuthenticatedUser Long userId,
+                                              @PathVariable Long commentId) {
+        destroyCommentUsecase.execute(userId, commentId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Login
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePost(@AuthenticatedUser Long userId,
+                                           @PathVariable Long postId) {
+        destroyPostUsecase.execute(userId, postId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/com/numble/instagram/presentation/post/PostControllerDocsTest.java
+++ b/src/test/java/com/numble/instagram/presentation/post/PostControllerDocsTest.java
@@ -31,6 +31,7 @@ import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
@@ -67,6 +68,12 @@ class PostControllerDocsTest {
     private CreatePostLikeUsecase createPostLikeUsecase;
     @MockBean
     private DestroyPostLikeUsecase destroyPostLikeUsecase;
+    @MockBean
+    private DestroyPostUsecase destroyPostUsecase;
+    @MockBean
+    private DestroyCommentUsecase destroyCommentUsecase;
+    @MockBean
+    private DestroyReplyUsecase destroyReplyUsecase;
     @Autowired
     private WebApplicationContext webApplicationContext;
     private static final String DOCUMENT_IDENTIFIER = "post/{method-name}/";
@@ -352,5 +359,66 @@ class PostControllerDocsTest {
                                 fieldWithPath("postId").description("좋아요 취소 한 post id")
                         )
                 ));
+    }
+
+    @Test
+    @DisplayName("글 삭제는 완료되어야 한다.")
+    void deletePost() throws Exception {
+        String authorizationHeader = "Bearer access-token";
+        Long userId = 1L;
+        Long postId = 1L;
+        given(tokenProvider.isValidToken(authorizationHeader)).willReturn(true);
+        given(tokenProvider.getUserId(authorizationHeader)).willReturn(userId);
+
+
+        mockMvc.perform(delete("/api/post/{postId}", postId)
+                        .header(HttpHeaders.AUTHORIZATION, authorizationHeader))
+                .andExpect(status().isNoContent())
+                .andDo(document(DOCUMENT_IDENTIFIER,
+                        pathParameters(
+                                parameterWithName("postId").description("삭제 할 글 id")
+                        )
+                ));
+        verify(destroyPostUsecase).execute(userId, postId);
+    }
+
+    @Test
+    @DisplayName("댓글 삭제는 완료되어야 한다.")
+    void deleteComment() throws Exception {
+        String authorizationHeader = "Bearer access-token";
+        Long userId = 1L;
+        Long commentId = 1L;
+        given(tokenProvider.isValidToken(authorizationHeader)).willReturn(true);
+        given(tokenProvider.getUserId(authorizationHeader)).willReturn(userId);
+
+        mockMvc.perform(delete("/api/post/comment/{commentId}", commentId)
+                        .header(HttpHeaders.AUTHORIZATION, authorizationHeader))
+                .andExpect(status().isNoContent())
+                .andDo(document(DOCUMENT_IDENTIFIER,
+                        pathParameters(
+                                parameterWithName("commentId").description("삭제 할 댓글 id")
+                        )
+                ));
+        verify(destroyCommentUsecase).execute(userId, commentId);
+    }
+
+    @Test
+    @DisplayName("답글 삭제는 완료되어야 한다.")
+    void deleteReply() throws Exception {
+        String authorizationHeader = "Bearer access-token";
+        Long userId = 1L;
+        Long replyId = 1L;
+        given(tokenProvider.isValidToken(authorizationHeader)).willReturn(true);
+        given(tokenProvider.getUserId(authorizationHeader)).willReturn(userId);
+
+        mockMvc.perform(delete("/api/post/reply/{replyId}", replyId)
+                        .header(HttpHeaders.AUTHORIZATION, authorizationHeader))
+                .andExpect(status().isNoContent())
+                .andDo(document(DOCUMENT_IDENTIFIER,
+                        pathParameters(
+                                parameterWithName("replyId").description("삭제 할 답글 id")
+                        )
+                ));
+        verify(destroyReplyUsecase).execute(userId, replyId);
     }
 }


### PR DESCRIPTION
## 작업 주제

- 글 삭제, 댓글 삭제, 답글 삭제 기능 

## optional 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 모든 삭제는 작성자를 확인 한 후 -> 삭제 되는 방향으로 구현했습니다. 
- OneToMany 인 경우는 ```cascade = CascadeType.ALL, orphanRemoval = true``` 옵션으로 삭제시 하위의 엔티티가 모두 삭제됩니다. 
- 다만 현재 delete 쿼리가 여러번 나가는 n + 1 문제가 발생하게 되는데 이를 해결하기 위해 한방 jpql 쿼리를 짜는 것은 불가능한 것으로 현재 판단됩니다. 

<img width="644" alt="스크린샷 2023-04-11 오전 4 26 04" src="https://user-images.githubusercontent.com/102657974/230989635-c2d5e6af-49d9-4a01-befb-83049bde67cc.png">

- 이렇게 네이티브 쿼리를 짜는 방향도 생각해봤지만 JPA와 호환성 문제가 발생하는 것이 두려워서 조금 더 알아보려고 합니다. 
- 또한 soft delete 하는 방법도 생각해봤지만 물리적으로 언젠가는 지워줘야할 것 같아 soft delete는 안하는 방향으로 잡았습니다. 
- 아쉬운 부분은 좀 더 생각해보고 수정하도록 하겠습니다. 

## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [x] base, compare branch가 적절하게 선택되었나요?
- [x] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)