### PR TITLE
DM 전송하기 기능 

### DIFF
--- a/src/docs/asciidoc/dm.adoc
+++ b/src/docs/asciidoc/dm.adoc
@@ -1,0 +1,17 @@
+== *DM*
+
+'''
+
+=== dm 전송
+==== Request
+include::{snippets}/dm/send-message/http-request.adoc[]
+- path parameter
+
+include::{snippets}/dm/send-message/path-parameters.adoc[]
+- body
+include::{snippets}/dm/send-message/request-fields.adoc[]
+
+==== Response
+include::{snippets}/dm/send-message/http-response.adoc[]
+- body
+include::{snippets}/dm/send-message/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,3 +15,5 @@ include::follow.adoc[]
 include::post.adoc[]
 
 include::feed.adoc[]
+
+include::dm.adoc[]

--- a/src/main/java/com/numble/instagram/application/usecase/dm/CreateMessageUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/dm/CreateMessageUsecase.java
@@ -1,0 +1,33 @@
+package com.numble.instagram.application.usecase.dm;
+
+import com.numble.instagram.domain.dm.entity.ChatRoom;
+import com.numble.instagram.domain.dm.entity.Message;
+import com.numble.instagram.domain.dm.service.ChatRoomWriteService;
+import com.numble.instagram.domain.dm.service.MessageWriteService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.request.dm.MessageRequest;
+import com.numble.instagram.dto.response.dm.MessageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreateMessageUsecase {
+
+    private final UserReadService userReadService;
+    private final MessageWriteService messageWriteService;
+    private final ChatRoomWriteService chatRoomWriteService;
+
+    @Transactional
+    public MessageResponse execute(Long fromUserId, Long toUserId, MessageRequest messageRequest) {
+        User fromUser = userReadService.getUser(fromUserId);
+        User toUser = userReadService.getUser(toUserId);
+
+        ChatRoom chatRoom = chatRoomWriteService.createOrGet(fromUser, toUser);
+        Message newMessage = messageWriteService.create(fromUser, toUser, chatRoom, messageRequest.content());
+
+        return MessageResponse.from(newMessage);
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/dm/entity/ChatRoom.java
+++ b/src/main/java/com/numble/instagram/domain/dm/entity/ChatRoom.java
@@ -2,6 +2,7 @@ package com.numble.instagram.domain.dm.entity;
 
 import com.numble.instagram.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,7 +28,7 @@ public class ChatRoom {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user2;
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "chatRoom", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Message> messages = new ArrayList<>();
 
     @Column(updatable = false)
@@ -36,5 +37,26 @@ public class ChatRoom {
     @PrePersist
     private void onPrePersist() {
         this.createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public ChatRoom(User user1, User user2, List<Message> messages) {
+        this.user1 = user1;
+        this.user2 = user2;
+        this.messages = messages;
+    }
+
+    public static ChatRoom create(Message newMessage) {
+        List<Message> messages = new ArrayList<>();
+        messages.add(newMessage);
+        return ChatRoom.builder()
+                .user1(newMessage.getFromUser())
+                .user2(newMessage.getToUser())
+                .messages(messages)
+                .build();
+    }
+
+    public void addMessage(Message newMessage) {
+        this.messages.add(newMessage);
     }
 }

--- a/src/main/java/com/numble/instagram/domain/dm/entity/ChatRoom.java
+++ b/src/main/java/com/numble/instagram/domain/dm/entity/ChatRoom.java
@@ -1,0 +1,40 @@
+package com.numble.instagram.domain.dm.entity;
+
+import com.numble.instagram.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user1;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user2;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    private List<Message> messages = new ArrayList<>();
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    private void onPrePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/dm/entity/ChatRoom.java
+++ b/src/main/java/com/numble/instagram/domain/dm/entity/ChatRoom.java
@@ -40,20 +40,9 @@ public class ChatRoom {
     }
 
     @Builder
-    public ChatRoom(User user1, User user2, List<Message> messages) {
+    public ChatRoom(User user1, User user2) {
         this.user1 = user1;
         this.user2 = user2;
-        this.messages = messages;
-    }
-
-    public static ChatRoom create(Message newMessage) {
-        List<Message> messages = new ArrayList<>();
-        messages.add(newMessage);
-        return ChatRoom.builder()
-                .user1(newMessage.getFromUser())
-                .user2(newMessage.getToUser())
-                .messages(messages)
-                .build();
     }
 
     public void addMessage(Message newMessage) {

--- a/src/main/java/com/numble/instagram/domain/dm/entity/Message.java
+++ b/src/main/java/com/numble/instagram/domain/dm/entity/Message.java
@@ -32,6 +32,10 @@ public class Message {
     @Enumerated(EnumType.STRING)
     private MessageType messageType;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id")
+    private ChatRoom chatRoom;
+
     @Column(updatable = false)
     private LocalDateTime sentAt;
 

--- a/src/main/java/com/numble/instagram/domain/dm/entity/Message.java
+++ b/src/main/java/com/numble/instagram/domain/dm/entity/Message.java
@@ -45,9 +45,22 @@ public class Message {
     }
 
     @Builder
-    public Message(String content, User fromUser, User toUser) {
+    public Message(String content, User fromUser, User toUser, ChatRoom chatRoom) {
         this.content = content;
         this.fromUser = fromUser;
         this.toUser = toUser;
+        this.messageType = MessageType.TEXT;
+        this.chatRoom = chatRoom;
+    }
+
+    public static Message create(String content, User fromUser, User toUser, ChatRoom chatRoom) {
+        Message newMessage = Message.builder()
+                .fromUser(fromUser)
+                .toUser(toUser)
+                .chatRoom(chatRoom)
+                .content(content)
+                .build();
+        chatRoom.addMessage(newMessage);
+        return newMessage;
     }
 }

--- a/src/main/java/com/numble/instagram/domain/dm/entity/Message.java
+++ b/src/main/java/com/numble/instagram/domain/dm/entity/Message.java
@@ -1,0 +1,49 @@
+package com.numble.instagram.domain.dm.entity;
+
+import com.numble.instagram.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class Message {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Lob
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User fromUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User toUser;
+
+    @Enumerated(EnumType.STRING)
+    private MessageType messageType;
+
+    @Column(updatable = false)
+    private LocalDateTime sentAt;
+
+    @PrePersist
+    private void onPrePersist() {
+        this.sentAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public Message(String content, User fromUser, User toUser) {
+        this.content = content;
+        this.fromUser = fromUser;
+        this.toUser = toUser;
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/dm/entity/MessageType.java
+++ b/src/main/java/com/numble/instagram/domain/dm/entity/MessageType.java
@@ -1,0 +1,5 @@
+package com.numble.instagram.domain.dm.entity;
+
+public enum MessageType {
+    TEXT, IMAGE
+}

--- a/src/main/java/com/numble/instagram/domain/dm/repository/ChatRoomRepository.java
+++ b/src/main/java/com/numble/instagram/domain/dm/repository/ChatRoomRepository.java
@@ -1,0 +1,19 @@
+package com.numble.instagram.domain.dm.repository;
+
+import com.numble.instagram.domain.dm.entity.ChatRoom;
+import com.numble.instagram.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    @Query("""
+            SELECT cr
+            FROM ChatRoom cr
+            WHERE (cr.user1 = :user1 AND cr.user2 = :user2) OR (cr.user1 = :user2 AND cr.user2 = :user1)
+            """)
+    Optional<ChatRoom> findChatRoomByUsers(@Param("user1") User user1, @Param("user2") User user2);
+}

--- a/src/main/java/com/numble/instagram/domain/dm/repository/MessageRepository.java
+++ b/src/main/java/com/numble/instagram/domain/dm/repository/MessageRepository.java
@@ -1,0 +1,7 @@
+package com.numble.instagram.domain.dm.repository;
+
+import com.numble.instagram.domain.dm.entity.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+}

--- a/src/main/java/com/numble/instagram/domain/dm/service/ChatRoomReadService.java
+++ b/src/main/java/com/numble/instagram/domain/dm/service/ChatRoomReadService.java
@@ -1,0 +1,21 @@
+package com.numble.instagram.domain.dm.service;
+
+import com.numble.instagram.domain.dm.entity.ChatRoom;
+import com.numble.instagram.domain.dm.repository.ChatRoomRepository;
+import com.numble.instagram.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatRoomReadService {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    public ChatRoom getChatRoom(User user1, User user2) {
+        return chatRoomRepository.findChatRoomByUsers(user1, user2)
+                .orElseThrow();
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/dm/service/ChatRoomWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/dm/service/ChatRoomWriteService.java
@@ -1,0 +1,30 @@
+package com.numble.instagram.domain.dm.service;
+
+import com.numble.instagram.domain.dm.entity.ChatRoom;
+import com.numble.instagram.domain.dm.repository.ChatRoomRepository;
+import com.numble.instagram.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatRoomWriteService {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    public ChatRoom createOrGet(User user1, User user2) {
+        Optional<ChatRoom> findChatRoom = chatRoomRepository.findChatRoomByUsers(user1, user2);
+        if (findChatRoom.isPresent()) {
+            return findChatRoom.get();
+        }
+        ChatRoom chatRoom = ChatRoom.builder()
+                .user1(user1)
+                .user2(user2)
+                .build();
+        return chatRoomRepository.save(chatRoom);
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/dm/service/MessageWriteService.java
+++ b/src/main/java/com/numble/instagram/domain/dm/service/MessageWriteService.java
@@ -1,0 +1,22 @@
+package com.numble.instagram.domain.dm.service;
+
+import com.numble.instagram.domain.dm.entity.ChatRoom;
+import com.numble.instagram.domain.dm.entity.Message;
+import com.numble.instagram.domain.dm.repository.MessageRepository;
+import com.numble.instagram.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MessageWriteService {
+
+    private final MessageRepository messageRepository;
+
+    public Message create(User fromUser, User toUser, ChatRoom chatRoom, String content) {
+        Message newMessage = Message.create(content, fromUser, toUser, chatRoom);
+        return messageRepository.save(newMessage);
+    }
+}

--- a/src/main/java/com/numble/instagram/dto/request/dm/MessageRequest.java
+++ b/src/main/java/com/numble/instagram/dto/request/dm/MessageRequest.java
@@ -1,0 +1,4 @@
+package com.numble.instagram.dto.request.dm;
+
+public record MessageRequest(String content) {
+}

--- a/src/main/java/com/numble/instagram/dto/response/dm/MessageResponse.java
+++ b/src/main/java/com/numble/instagram/dto/response/dm/MessageResponse.java
@@ -1,0 +1,10 @@
+package com.numble.instagram.dto.response.dm;
+
+import com.numble.instagram.domain.dm.entity.Message;
+
+public record MessageResponse(Long userId, String content) {
+
+    public static MessageResponse from(Message message) {
+        return new MessageResponse(message.getToUser().getId(), message.getContent());
+    }
+}

--- a/src/main/java/com/numble/instagram/exception/notfound/ChatRoomNotFoundException.java
+++ b/src/main/java/com/numble/instagram/exception/notfound/ChatRoomNotFoundException.java
@@ -1,0 +1,8 @@
+package com.numble.instagram.exception.notfound;
+
+public class ChatRoomNotFoundException extends NotFoundException {
+
+    public ChatRoomNotFoundException() {
+        addValidation("chatroom", "채팅방을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/numble/instagram/presentation/dm/DmController.java
+++ b/src/main/java/com/numble/instagram/presentation/dm/DmController.java
@@ -1,0 +1,25 @@
+package com.numble.instagram.presentation.dm;
+
+import com.numble.instagram.application.usecase.dm.CreateMessageUsecase;
+import com.numble.instagram.dto.request.dm.MessageRequest;
+import com.numble.instagram.dto.response.dm.MessageResponse;
+import com.numble.instagram.presentation.auth.AuthenticatedUser;
+import com.numble.instagram.presentation.auth.Login;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/dm")
+public class DmController {
+
+    private final CreateMessageUsecase createMessageUsecase;
+
+    @Login
+    @PostMapping("/{toUserId}")
+    public MessageResponse sendMessage(@AuthenticatedUser Long fromUserId,
+                                       @PathVariable Long toUserId,
+                                       @RequestBody MessageRequest messageRequest) {
+        return createMessageUsecase.execute(fromUserId, toUserId, messageRequest);
+    }
+}

--- a/src/test/java/com/numble/instagram/application/usecase/dm/CreateMessageUsecaseTest.java
+++ b/src/test/java/com/numble/instagram/application/usecase/dm/CreateMessageUsecaseTest.java
@@ -1,0 +1,57 @@
+package com.numble.instagram.application.usecase.dm;
+
+import com.numble.instagram.domain.dm.entity.ChatRoom;
+import com.numble.instagram.domain.dm.entity.Message;
+import com.numble.instagram.domain.dm.service.ChatRoomWriteService;
+import com.numble.instagram.domain.dm.service.MessageWriteService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.request.dm.MessageRequest;
+import com.numble.instagram.dto.response.dm.MessageResponse;
+import com.numble.instagram.util.fixture.dm.ChatRoomFixture;
+import com.numble.instagram.util.fixture.dm.MessageFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CreateMessageUsecaseTest {
+
+    @InjectMocks
+    private CreateMessageUsecase createMessageUsecase;
+    @Mock
+    private UserReadService userReadService;
+    @Mock
+    private MessageWriteService messageWriteService;
+    @Mock
+    private ChatRoomWriteService chatRoomWriteService;
+
+    @Test
+    @DisplayName("Message는 생성된다.")
+    public void execute() {
+        Long fromUserId = 1L;
+        Long toUserId = 2L;
+        User fromUser = UserFixture.create(fromUserId, "fromUser");
+        User toUser = UserFixture.create(toUserId, "toUser");
+        ChatRoom chatRoom = ChatRoomFixture.create(fromUser, toUser);
+        MessageRequest messageRequest = new MessageRequest("new-message-content");
+        Message message = MessageFixture.create(messageRequest.content(), fromUser, toUser, chatRoom);
+
+        when(userReadService.getUser(fromUserId)).thenReturn(fromUser);
+        when(userReadService.getUser(toUserId)).thenReturn(toUser);
+        when(chatRoomWriteService.createOrGet(fromUser, toUser)).thenReturn(chatRoom);
+        when(messageWriteService.create(fromUser, toUser, chatRoom, messageRequest.content())).thenReturn(message);
+
+        MessageResponse result = createMessageUsecase.execute(fromUserId, toUserId, messageRequest);
+
+        assertEquals(toUserId, result.userId());
+        assertEquals(messageRequest.content(), result.content());
+    }
+}

--- a/src/test/java/com/numble/instagram/domain/dm/service/ChatRoomWriteServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/dm/service/ChatRoomWriteServiceTest.java
@@ -1,0 +1,58 @@
+package com.numble.instagram.domain.dm.service;
+
+import com.numble.instagram.domain.dm.entity.ChatRoom;
+import com.numble.instagram.domain.dm.repository.ChatRoomRepository;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.util.fixture.dm.ChatRoomFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomWriteServiceTest {
+
+    @InjectMocks
+    private ChatRoomWriteService chatRoomWriteService;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Test
+    @DisplayName("chatroom이 존재하면 가져온다. 새로 생성하지 않고")
+    void createOrGet_existingChatRoom() {
+        User user1 = UserFixture.create("user1");
+        User user2 = UserFixture.create("user2");
+        ChatRoom chatRoom = ChatRoomFixture.create(user1, user2);
+
+        when(chatRoomRepository.findChatRoomByUsers(user1, user2)).thenReturn(Optional.of(chatRoom));
+
+        ChatRoom result = chatRoomWriteService.createOrGet(user1, user2);
+
+        assertEquals(chatRoom, result);
+    }
+
+    @Test
+    @DisplayName("chatroom이 존재하지 않으면 새로 생성한다.")
+    void createOrGet_newChatRoom() {
+        User user1 = UserFixture.create("user1");
+        User user2 = UserFixture.create("user2");
+        ChatRoom chatRoom = ChatRoomFixture.create(user1, user2);
+
+        when(chatRoomRepository.findChatRoomByUsers(user1, user2)).thenReturn(Optional.empty());
+        when(chatRoomRepository.save(any(ChatRoom.class))).thenReturn(chatRoom);
+
+        ChatRoom result = chatRoomWriteService.createOrGet(user1, user2);
+
+        assertEquals(chatRoom, result);
+    }
+}

--- a/src/test/java/com/numble/instagram/domain/dm/service/MessageWriteServiceTest.java
+++ b/src/test/java/com/numble/instagram/domain/dm/service/MessageWriteServiceTest.java
@@ -1,0 +1,46 @@
+package com.numble.instagram.domain.dm.service;
+
+import com.numble.instagram.domain.dm.entity.ChatRoom;
+import com.numble.instagram.domain.dm.entity.Message;
+import com.numble.instagram.domain.dm.repository.MessageRepository;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.util.fixture.dm.ChatRoomFixture;
+import com.numble.instagram.util.fixture.dm.MessageFixture;
+import com.numble.instagram.util.fixture.user.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MessageWriteServiceTest {
+
+    @InjectMocks
+    private MessageWriteService messageWriteService;
+
+    @Mock
+    private MessageRepository messageRepository;
+
+    @Test
+    @DisplayName("Message는 생성된다.")
+    void createMessage() {
+        User fromUser = UserFixture.create("fromUser");
+        User toUser = UserFixture.create("toUser");
+        ChatRoom chatRoom = ChatRoomFixture.create(fromUser, toUser);
+        String content = "new-message-content";
+
+        Message message = MessageFixture.create(content, fromUser, toUser, chatRoom);
+
+        when(messageRepository.save(any(Message.class))).thenReturn(message);
+
+        Message result = messageWriteService.create(fromUser, toUser, chatRoom, content);
+
+        assertEquals(message, result);
+    }
+}

--- a/src/test/java/com/numble/instagram/presentation/dm/DmControllerDocsTest.java
+++ b/src/test/java/com/numble/instagram/presentation/dm/DmControllerDocsTest.java
@@ -1,0 +1,95 @@
+package com.numble.instagram.presentation.dm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.numble.instagram.application.auth.token.TokenProvider;
+import com.numble.instagram.application.usecase.dm.CreateMessageUsecase;
+import com.numble.instagram.dto.request.dm.MessageRequest;
+import com.numble.instagram.dto.response.dm.MessageResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
+class DmControllerDocsTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+    private MockMvc mockMvc;
+    @MockBean
+    private TokenProvider tokenProvider;
+    @MockBean
+    private CreateMessageUsecase createMessageUsecase;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+    private static final String DOCUMENT_IDENTIFIER = "dm/{method-name}/";
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint(), modifyHeaders().remove("Vary")))
+                .build();
+    }
+
+    @Test
+    @DisplayName("dm은 전송된다.")
+    void sendMessage() throws Exception {
+        String authorizationHeader = "Bearer access-token";
+        Long fromUserId = 1L;
+        Long toUserId = 2L;
+        given(tokenProvider.isValidToken(authorizationHeader)).willReturn(true);
+        given(tokenProvider.getUserId(authorizationHeader)).willReturn(fromUserId);
+
+        MessageRequest messageRequest = new MessageRequest("새로운 메시지입니다.");
+        MessageResponse messageResponse = new MessageResponse(toUserId, messageRequest.content());
+
+        given(createMessageUsecase.execute(fromUserId, toUserId, messageRequest)).willReturn(messageResponse);
+
+        String json = objectMapper.writeValueAsString(messageRequest);
+
+        mockMvc.perform(post("/api/dm/{toUserId}", toUserId)
+                        .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andDo(document(DOCUMENT_IDENTIFIER,
+                        pathParameters(
+                                parameterWithName("toUserId").description("dm 전송할 user Id")
+                        ),
+                        requestFields(
+                                fieldWithPath("content").description("메시지 내용")
+                        ),
+                        responseFields(
+                                fieldWithPath("userId").description("전송한 user Id"),
+                                fieldWithPath("content").description("전송 된 메시지 내용")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/numble/instagram/util/fixture/dm/ChatRoomFixture.java
+++ b/src/test/java/com/numble/instagram/util/fixture/dm/ChatRoomFixture.java
@@ -1,0 +1,11 @@
+package com.numble.instagram.util.fixture.dm;
+
+import com.numble.instagram.domain.dm.entity.ChatRoom;
+import com.numble.instagram.domain.user.entity.User;
+
+public class ChatRoomFixture {
+
+    public static ChatRoom create(User user1, User user2) {
+        return new ChatRoom(user1, user2);
+    }
+}

--- a/src/test/java/com/numble/instagram/util/fixture/dm/MessageFixture.java
+++ b/src/test/java/com/numble/instagram/util/fixture/dm/MessageFixture.java
@@ -1,0 +1,12 @@
+package com.numble.instagram.util.fixture.dm;
+
+import com.numble.instagram.domain.dm.entity.ChatRoom;
+import com.numble.instagram.domain.dm.entity.Message;
+import com.numble.instagram.domain.user.entity.User;
+
+public class MessageFixture {
+
+    public static Message create(String content, User fromUser, User toUser, ChatRoom chatRoom) {
+        return Message.create(content, fromUser, toUser, chatRoom);
+    }
+}


### PR DESCRIPTION
## 작업 주제

- DM 전송하는 기능입니다. 

## optional 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- Message entity와 ChatRoom entity를 생성했습니다. 
- 메시지 전송 요청시 fromUser와 toUser 상관없이 1:1 채팅방인 chatroom을 가져옵니다.  
- fromUser와 toUser가 있는 메시지를 생성하고 chatroom에 추가 해줍니다. 
- 양방향 연관관계를 처음부터 만들어 주었습니다. 
- 사실 처음에는 OneToMany로 단방향 연관관계를 시도하였으나 두 테이블의 중간 테이블이 생기고, 메시지를 chatroom에 추가 할 때마다 한번의 delete 쿼리와 insert쿼리 여러번 나가는 것, 왜 OneToMany 단방향을 지양해야 되는지 깨닫는 대목이었습니다.

## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [x] base, compare branch가 적절하게 선택되었나요?
- [x] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)