### PR TITLE
DM 목록 조회하기 기능

### DIFF
--- a/src/docs/asciidoc/dm.adoc
+++ b/src/docs/asciidoc/dm.adoc
@@ -18,16 +18,29 @@ include::{snippets}/dm/send-message/response-fields.adoc[]
 
 '''
 
-=== DM 상세내역 조회 with messages
+=== DM 목록 조회
 ==== Request
 include::{snippets}/dm/get-chat-room/http-request.adoc[]
 - query parameter
 include::{snippets}/dm/get-chat-room/query-parameters.adoc[]
-- path parameter
-
-include::{snippets}/dm/get-chat-room/path-parameters.adoc[]
 
 ==== Response
 include::{snippets}/dm/get-chat-room/http-response.adoc[]
 - body
 include::{snippets}/dm/get-chat-room/response-fields.adoc[]
+
+'''
+
+=== DM 상세내역 조회 with messages
+==== Request
+include::{snippets}/dm/get-chat-room-with-messages/http-request.adoc[]
+- query parameter
+include::{snippets}/dm/get-chat-room-with-messages/query-parameters.adoc[]
+- path parameter
+
+include::{snippets}/dm/get-chat-room-with-messages/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/dm/get-chat-room-with-messages/http-response.adoc[]
+- body
+include::{snippets}/dm/get-chat-room-with-messages/response-fields.adoc[]

--- a/src/main/java/com/numble/instagram/application/usecase/dm/GetChatRoomsUsecase.java
+++ b/src/main/java/com/numble/instagram/application/usecase/dm/GetChatRoomsUsecase.java
@@ -1,0 +1,38 @@
+package com.numble.instagram.application.usecase.dm;
+
+import com.numble.instagram.domain.dm.dto.ChatRoomWithLastMessage;
+import com.numble.instagram.domain.dm.service.ChatRoomReadService;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.domain.user.service.UserReadService;
+import com.numble.instagram.dto.response.dm.ChatRoomWithMessageResponse;
+import com.numble.instagram.support.paging.CursorRequest;
+import com.numble.instagram.support.paging.PageCursor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetChatRoomsUsecase {
+
+    private final UserReadService userReadService;
+    private final ChatRoomReadService chatRoomReadService;
+
+    public PageCursor<ChatRoomWithMessageResponse> execute(Long userId, CursorRequest cursorRequest) {
+        User user = userReadService.getUser(userId);
+        List<ChatRoomWithLastMessage> chatRoomWithLastMessages =
+                chatRoomReadService.getChatRoomsWithLastMessage(user, cursorRequest);
+
+        Long nextKey = chatRoomWithLastMessages.stream()
+                .mapToLong(cm -> cm.chatRoom().getId())
+                .min()
+                .orElse(CursorRequest.NONE_KEY);
+
+        List<ChatRoomWithMessageResponse> chatRoomWithMessageResponses = chatRoomWithLastMessages.stream()
+                .map(cm -> ChatRoomWithMessageResponse.from(cm.chatRoom(), cm.lastMessage()))
+                .toList();
+
+        return PageCursor.fromChatRoomWithMessageResponse(cursorRequest.next(nextKey), chatRoomWithMessageResponses);
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/dm/dto/ChatRoomWithLastMessage.java
+++ b/src/main/java/com/numble/instagram/domain/dm/dto/ChatRoomWithLastMessage.java
@@ -1,0 +1,7 @@
+package com.numble.instagram.domain.dm.dto;
+
+import com.numble.instagram.domain.dm.entity.ChatRoom;
+import com.numble.instagram.domain.dm.entity.Message;
+
+public record ChatRoomWithLastMessage(ChatRoom chatRoom, Message lastMessage) {
+}

--- a/src/main/java/com/numble/instagram/domain/dm/repository/ChatRoomRepository.java
+++ b/src/main/java/com/numble/instagram/domain/dm/repository/ChatRoomRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomRepositoryCustom {
 
     @Query("""
             SELECT cr

--- a/src/main/java/com/numble/instagram/domain/dm/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/numble/instagram/domain/dm/repository/ChatRoomRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.numble.instagram.domain.dm.repository;
+
+import com.numble.instagram.domain.dm.dto.ChatRoomWithLastMessage;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.support.paging.CursorRequest;
+
+import java.util.List;
+
+public interface ChatRoomRepositoryCustom {
+
+    List<ChatRoomWithLastMessage> findChatRoomsByUserWithLatestMessage(User user, CursorRequest cursorRequest);
+}

--- a/src/main/java/com/numble/instagram/domain/dm/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/numble/instagram/domain/dm/repository/ChatRoomRepositoryImpl.java
@@ -1,0 +1,58 @@
+package com.numble.instagram.domain.dm.repository;
+
+import com.numble.instagram.domain.dm.dto.ChatRoomWithLastMessage;
+import com.numble.instagram.domain.dm.entity.QMessage;
+import com.numble.instagram.domain.user.entity.User;
+import com.numble.instagram.support.paging.CursorRequest;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.numble.instagram.domain.dm.entity.QChatRoom.chatRoom;
+import static com.numble.instagram.domain.dm.entity.QMessage.message;
+
+@RequiredArgsConstructor
+public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<ChatRoomWithLastMessage> findChatRoomsByUserWithLatestMessage(User user, CursorRequest cursorRequest) {
+        QMessage latestMessage = new QMessage("latestMessage");
+
+        List<Tuple> tuples = jpaQueryFactory.select(chatRoom, latestMessage)
+                .from(chatRoom)
+                .distinct()
+                .leftJoin(chatRoom.messages, latestMessage)
+                .on(
+                        latestMessage.id.eq(
+                                jpaQueryFactory.select(message.id.max())
+                                        .from(message)
+                                        .where(message.chatRoom.eq(chatRoom))))
+                .where(
+                        isChatRoomUser(user),
+                        lessThanChatRoomId(cursorRequest)
+                )
+                .orderBy(chatRoom.id.desc())
+                .limit(cursorRequest.size())
+                .fetch();
+
+        return tuples.stream()
+                .map(tuple -> new ChatRoomWithLastMessage(tuple.get(chatRoom), tuple.get(latestMessage)))
+                .toList();
+    }
+
+    private BooleanExpression isChatRoomUser(User user) {
+        return chatRoom.user1.eq(user).or(chatRoom.user2.eq(user));
+    }
+
+    private BooleanExpression lessThanChatRoomId(CursorRequest cursorRequest) {
+        if (cursorRequest.hasKey()) {
+            return chatRoom.id.lt(cursorRequest.key());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/numble/instagram/domain/dm/service/ChatRoomReadService.java
+++ b/src/main/java/com/numble/instagram/domain/dm/service/ChatRoomReadService.java
@@ -1,13 +1,17 @@
 package com.numble.instagram.domain.dm.service;
 
+import com.numble.instagram.domain.dm.dto.ChatRoomWithLastMessage;
 import com.numble.instagram.domain.dm.entity.ChatRoom;
 import com.numble.instagram.domain.dm.repository.ChatRoomRepository;
 import com.numble.instagram.domain.user.entity.User;
 import com.numble.instagram.exception.badrequest.NotChatRoomUserException;
 import com.numble.instagram.exception.notfound.ChatRoomNotFoundException;
+import com.numble.instagram.support.paging.CursorRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +30,10 @@ public class ChatRoomReadService {
                 .orElseThrow(ChatRoomNotFoundException::new);
         checkChatRoomUser(user, chatRoom);
         return chatRoom;
+    }
+
+    public List<ChatRoomWithLastMessage> getChatRoomsWithLastMessage(User user, CursorRequest cursorRequest) {
+        return chatRoomRepository.findChatRoomsByUserWithLatestMessage(user, cursorRequest);
     }
 
     private static void checkChatRoomUser(User user, ChatRoom chatRoom) {

--- a/src/main/java/com/numble/instagram/dto/response/dm/ChatRoomWithMessageResponse.java
+++ b/src/main/java/com/numble/instagram/dto/response/dm/ChatRoomWithMessageResponse.java
@@ -1,0 +1,27 @@
+package com.numble.instagram.dto.response.dm;
+
+import com.numble.instagram.domain.dm.entity.ChatRoom;
+import com.numble.instagram.domain.dm.entity.Message;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ChatRoomWithMessageResponse(
+        Long chatroomId,
+        String nickname,
+        String profileImageUrl,
+        String lastMessageContent,
+        LocalDateTime lastSentAt
+) {
+
+    public static ChatRoomWithMessageResponse from(ChatRoom chatRoom, Message lastMessage) {
+        return ChatRoomWithMessageResponse.builder()
+                .chatroomId(chatRoom.getId())
+                .nickname(lastMessage.getFromUser().getNickname())
+                .profileImageUrl(lastMessage.getFromUser().getProfileImageUrl())
+                .lastMessageContent(lastMessage.getContent())
+                .lastSentAt(lastMessage.getSentAt())
+                .build();
+    }
+}

--- a/src/main/java/com/numble/instagram/presentation/dm/DmController.java
+++ b/src/main/java/com/numble/instagram/presentation/dm/DmController.java
@@ -2,7 +2,9 @@ package com.numble.instagram.presentation.dm;
 
 import com.numble.instagram.application.usecase.dm.CreateMessageUsecase;
 import com.numble.instagram.application.usecase.dm.GetChatRoomWithMessagesUsecase;
+import com.numble.instagram.application.usecase.dm.GetChatRoomsUsecase;
 import com.numble.instagram.dto.request.dm.MessageRequest;
+import com.numble.instagram.dto.response.dm.ChatRoomWithMessageResponse;
 import com.numble.instagram.dto.response.dm.MessageDetailResponse;
 import com.numble.instagram.dto.response.dm.MessageResponse;
 import com.numble.instagram.presentation.auth.AuthenticatedUser;
@@ -19,6 +21,7 @@ public class DmController {
 
     private final CreateMessageUsecase createMessageUsecase;
     private final GetChatRoomWithMessagesUsecase getChatRoomWithMessagesUsecase;
+    private final GetChatRoomsUsecase getChatRoomsUsecase;
 
     @Login
     @PostMapping("/{toUserId}")
@@ -30,9 +33,16 @@ public class DmController {
 
     @Login
     @GetMapping("/chatroom/{chatroomId}")
-    public PageCursor<MessageDetailResponse> getChatRoom(@AuthenticatedUser Long userId,
-                                                         @PathVariable Long chatroomId,
-                                                         CursorRequest cursorRequest) {
+    public PageCursor<MessageDetailResponse> getChatRoomWithMessages(@AuthenticatedUser Long userId,
+                                                                     @PathVariable Long chatroomId,
+                                                                     CursorRequest cursorRequest) {
         return getChatRoomWithMessagesUsecase.execute(userId, chatroomId, cursorRequest);
+    }
+
+    @Login
+    @GetMapping("/chatroom")
+    public PageCursor<ChatRoomWithMessageResponse> getChatRooms(@AuthenticatedUser Long userId,
+                                                                CursorRequest cursorRequest) {
+        return getChatRoomsUsecase.execute(userId, cursorRequest);
     }
 }

--- a/src/main/java/com/numble/instagram/support/paging/PageCursor.java
+++ b/src/main/java/com/numble/instagram/support/paging/PageCursor.java
@@ -1,5 +1,6 @@
 package com.numble.instagram.support.paging;
 
+import com.numble.instagram.dto.response.dm.ChatRoomWithMessageResponse;
 import com.numble.instagram.dto.response.dm.MessageDetailResponse;
 import com.numble.instagram.dto.response.post.PostDetailResponse;
 
@@ -15,5 +16,10 @@ public record PageCursor<T>(CursorRequest nextCursorRequest, List<T> body) {
     public static PageCursor<MessageDetailResponse> fromMessageDetailResponse(
             CursorRequest nextCursorRequest, List<MessageDetailResponse> messages) {
         return new PageCursor<>(nextCursorRequest, messages);
+    }
+
+    public static PageCursor<ChatRoomWithMessageResponse> fromChatRoomWithMessageResponse(
+            CursorRequest nextCursorRequest, List<ChatRoomWithMessageResponse> chatRooms) {
+        return new PageCursor<>(nextCursorRequest, chatRooms);
     }
 }


### PR DESCRIPTION
## 작업 주제

- DM 목록 조회하기 기능입니다. 

## optional 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- DM목록은 유저의 채팅방 목록을 가져옵니다. 채팅방 목록을 가져올 때 마지막 메세지도 함께 가져오기 때문에 다음과 같은 쿼리문을 이용했습니다. 

```java
@RequiredArgsConstructor
public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {

    private final JPAQueryFactory jpaQueryFactory;

    @Override
    public List<ChatRoomWithLastMessage> findChatRoomsByUserWithLatestMessage(User user, CursorRequest cursorRequest) {
        QMessage latestMessage = new QMessage("latestMessage");

        List<Tuple> tuples = jpaQueryFactory.select(chatRoom, latestMessage)
                .from(chatRoom)
                .distinct()
                .leftJoin(chatRoom.messages, latestMessage)
                .on(
                        latestMessage.id.eq(
                                jpaQueryFactory.select(message.id.max())
                                        .from(message)
                                        .where(message.chatRoom.eq(chatRoom))))
                .where(
                        isChatRoomUser(user),
                        lessThanChatRoomId(cursorRequest)
                )
                .orderBy(chatRoom.id.desc())
                .limit(cursorRequest.size())
                .fetch();

        return tuples.stream()
                .map(tuple -> new ChatRoomWithLastMessage(tuple.get(chatRoom), tuple.get(latestMessage)))
                .toList();
    }

    private BooleanExpression isChatRoomUser(User user) {
        return chatRoom.user1.eq(user).or(chatRoom.user2.eq(user));
    }

    private BooleanExpression lessThanChatRoomId(CursorRequest cursorRequest) {
        if (cursorRequest.hasKey()) {
            return chatRoom.id.lt(cursorRequest.key());
        }
        return null;
    }
}
```

- 고민 되었던 부분은 join시 단일 목록을 가져오기 위해 distinct를 이용한 점
- 마지막 message를 가져오기 위해 서브쿼리를 이용한 점입니다. 서브쿼리를 최대한 피하고 싶었지만 당장 생각나는게 서브쿼리여서 이용했습니다. 추후에 더 좋은 쿼리 최적화방법이 있다면 고려해보겠습니다. 
- 또한 마지막 메시지이기 때문에 조건을 sentAt으로 설정할 수 있었지만 id에는 기본적으로 index가 걸려있어 자동 증가되는 id를 조건으로 줬습니다.  

- 마지막으로 고민 했던 부분은 요구사항에는 chatRoomId를 cursor의 키로 이용하는데 채팅방 목록 특성상 마지막 메세지를 기준으로 정렬해서 가져오는게 좋지 않을까 싶습니다. 챌린지가 끝나면 마지막 메시지를 기준으로 정렬하는 방법을 선택할것 같습니다. 
 
## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [x] base, compare branch가 적절하게 선택되었나요?
- [x] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)